### PR TITLE
Feature/verify access

### DIFF
--- a/client/src/main/java/tds/session/ExternalSessionConfiguration.java
+++ b/client/src/main/java/tds/session/ExternalSessionConfiguration.java
@@ -22,6 +22,14 @@ public class ExternalSessionConfiguration {
                                         String environment,
                                         int shiftWindowStart,
                                         int shiftWindowEnd) {
+        if (clientName == null) {
+            throw new IllegalArgumentException("clientname cannot be null");
+        }
+
+        if (environment == null) {
+            throw new IllegalArgumentException("environment cannot be null");
+        }
+
         this.clientName = clientName;
         this.environment = environment;
         this.shiftWindowStart = shiftWindowStart;
@@ -68,8 +76,7 @@ public class ExternalSessionConfiguration {
      * @return True if the environment is set to "simulation" (case-insensitive); otherwise false.
      */
     public boolean isInSimulationEnvironment() {
-        return this.getEnvironment() != null
-            && this.getEnvironment().equalsIgnoreCase(SIMULATION_ENVIRONMENT);
+        return this.getEnvironment().equalsIgnoreCase(SIMULATION_ENVIRONMENT);
     }
 
     /**
@@ -78,7 +85,6 @@ public class ExternalSessionConfiguration {
      * @return True if the environment is set to "development" (case-insensitive); otherwise false.
      */
     public boolean isInDevelopmentEnvironment() {
-        return this.getEnvironment() != null
-            && this.getEnvironment().equalsIgnoreCase(DEVELOPMENT_ENVIRONMENT);
+        return this.getEnvironment().equalsIgnoreCase(DEVELOPMENT_ENVIRONMENT);
     }
 }

--- a/client/src/main/java/tds/session/ExternalSessionConfiguration.java
+++ b/client/src/main/java/tds/session/ExternalSessionConfiguration.java
@@ -68,7 +68,8 @@ public class ExternalSessionConfiguration {
      * @return True if the environment is set to "simulation" (case-insensitive); otherwise false.
      */
     public boolean isInSimulationEnvironment() {
-        return this.getEnvironment().equalsIgnoreCase(SIMULATION_ENVIRONMENT);
+        return this.getEnvironment() != null
+            && this.getEnvironment().equalsIgnoreCase(SIMULATION_ENVIRONMENT);
     }
 
     /**
@@ -77,6 +78,7 @@ public class ExternalSessionConfiguration {
      * @return True if the environment is set to "development" (case-insensitive); otherwise false.
      */
     public boolean isInDevelopmentEnvironment() {
-        return this.getEnvironment().equalsIgnoreCase(DEVELOPMENT_ENVIRONMENT);
+        return this.getEnvironment() != null
+            && this.getEnvironment().equalsIgnoreCase(DEVELOPMENT_ENVIRONMENT);
     }
 }

--- a/client/src/main/java/tds/session/ExternalSessionConfiguration.java
+++ b/client/src/main/java/tds/session/ExternalSessionConfiguration.java
@@ -4,6 +4,9 @@ package tds.session;
  * configuration properties for the session system
  */
 public class ExternalSessionConfiguration {
+    final String SIMULATION_ENVIRONMENT = "simulation";
+    final String DEVELOPMENT_ENVIRONMENT = "development";
+
     private String clientName;
     private String environment;
     private int shiftWindowStart;
@@ -57,5 +60,23 @@ public class ExternalSessionConfiguration {
      */
     public int getShiftWindowEnd() {
         return shiftWindowEnd;
+    }
+
+    /**
+     * Determine if this {@link ExternalSessionConfiguration} is configured for the Simulation environment.
+     *
+     * @return True if the environment is set to "simulation" (case-insensitive); otherwise false.
+     */
+    public boolean isInSimulationEnvironment() {
+        return this.getEnvironment().equalsIgnoreCase(SIMULATION_ENVIRONMENT);
+    }
+
+    /**
+     * Determine if this {@link ExternalSessionConfiguration} is configured for the Development environment.
+     *
+     * @return True if the environment is set to "development" (case-insensitive); otherwise false.
+     */
+    public boolean isInDevelopmentEnvironment() {
+        return this.getEnvironment().equalsIgnoreCase(DEVELOPMENT_ENVIRONMENT);
     }
 }

--- a/client/src/main/java/tds/session/Session.java
+++ b/client/src/main/java/tds/session/Session.java
@@ -234,6 +234,20 @@ public class Session {
     }
 
     /**
+     * Determine if the session is managed by a Proctor
+     * <p>
+     *     A session can be "proctorless" if the "AnonymousTestee" flag is turned on in the
+     *     {@code configs.client_systemflags} table.  A user taking a practice test is another example of a "proctorless"
+     *     session.
+     * </p>
+     *
+     * @return True if the {@code proctorId} is null; otherwise false
+     */
+    public boolean isProctorless() {
+        return this.getProctorId() == null;
+    }
+
+    /**
      * Determine if this {@link Session} is a Guest Session.
      * <p>
      *     A Guest session is created when a user takes a practice assessment without logging into the Student

--- a/client/src/test/java/tds/session/ExternalSessionConfigurationTest.java
+++ b/client/src/test/java/tds/session/ExternalSessionConfigurationTest.java
@@ -44,17 +44,24 @@ public class ExternalSessionConfigurationTest {
         assertThat(externalSessionConfiguration.isInDevelopmentEnvironment()).isFalse();
     }
 
-    @Test
-    public void shouldReturnFalseForIsInSimulationEnvironmentAndIsInDevelopmentEnvironmentWhenEnvironmentIsNull() {
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionBecauseClientNameIsNull() {
+        ExternalSessionConfiguration externalSessionConfiguration =
+            new ExternalSessionConfiguration(
+                null,
+                "Production",
+                0,
+                0);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldThrowIllegalArgumentExceptionBecauseEnvironmentIsNull() {
         ExternalSessionConfiguration externalSessionConfiguration =
             new ExternalSessionConfiguration(
                 "UNIT_TEST",
                 null,
                 0,
                 0);
-
-        assertThat(externalSessionConfiguration.isInSimulationEnvironment()).isFalse();
-        assertThat(externalSessionConfiguration.isInDevelopmentEnvironment()).isFalse();
     }
 }
 

--- a/client/src/test/java/tds/session/ExternalSessionConfigurationTest.java
+++ b/client/src/test/java/tds/session/ExternalSessionConfigurationTest.java
@@ -1,0 +1,48 @@
+package tds.session;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExternalSessionConfigurationTest {
+    @Test
+    public void shouldReturnTrueForIsInSimulationEnvironment() {
+        ExternalSessionConfiguration externalSessionConfiguration =
+            new ExternalSessionConfiguration(
+                "UNIT_TEST",
+                "Simulation",
+                0,
+                0);
+
+        assertThat(externalSessionConfiguration.isInSimulationEnvironment()).isTrue();
+        assertThat(externalSessionConfiguration.isInDevelopmentEnvironment()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnTrueForIsInDevelopmentEnvironment() {
+        ExternalSessionConfiguration externalSessionConfiguration =
+            new ExternalSessionConfiguration(
+                "UNIT_TEST",
+                "Development",
+                0,
+                0);
+
+        assertThat(externalSessionConfiguration.isInDevelopmentEnvironment()).isTrue();
+        assertThat(externalSessionConfiguration.isInSimulationEnvironment()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnFalseForIsInSimulationEnvironmentAndIsInDevelopmentEnvironment() {
+        ExternalSessionConfiguration externalSessionConfiguration =
+            new ExternalSessionConfiguration(
+                "UNIT_TEST",
+                "Production",
+                0,
+                0);
+
+        assertThat(externalSessionConfiguration.isInSimulationEnvironment()).isFalse();
+        assertThat(externalSessionConfiguration.isInDevelopmentEnvironment()).isFalse();
+    }
+}
+
+

--- a/client/src/test/java/tds/session/ExternalSessionConfigurationTest.java
+++ b/client/src/test/java/tds/session/ExternalSessionConfigurationTest.java
@@ -43,6 +43,19 @@ public class ExternalSessionConfigurationTest {
         assertThat(externalSessionConfiguration.isInSimulationEnvironment()).isFalse();
         assertThat(externalSessionConfiguration.isInDevelopmentEnvironment()).isFalse();
     }
+
+    @Test
+    public void shouldReturnFalseForIsInSimulationEnvironmentAndIsInDevelopmentEnvironmentWhenEnvironmentIsNull() {
+        ExternalSessionConfiguration externalSessionConfiguration =
+            new ExternalSessionConfiguration(
+                "UNIT_TEST",
+                null,
+                0,
+                0);
+
+        assertThat(externalSessionConfiguration.isInSimulationEnvironment()).isFalse();
+        assertThat(externalSessionConfiguration.isInDevelopmentEnvironment()).isFalse();
+    }
 }
 
 

--- a/client/src/test/java/tds/session/SessionTest.java
+++ b/client/src/test/java/tds/session/SessionTest.java
@@ -122,4 +122,24 @@ public class SessionTest {
 
         assertThat(session.isGuestSession()).isFalse();
     }
+
+    @Test
+    public void shouldReturnTrueForIsProctorlessBecauseProctorIdIsNull() {
+        Session session = new Session.Builder()
+            .withId(UUID.randomUUID())
+            .withProctorId(null)
+            .build();
+
+        assertThat(session.isProctorless()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseForIsProctorlessBecauseProctorIdIsNotNull() {
+        Session session = new Session.Builder()
+            .withId(UUID.randomUUID())
+            .withProctorId(42L)
+            .build();
+
+        assertThat(session.isProctorless()).isFalse();
+    }
 }


### PR DESCRIPTION
- Adds `isInSimulationEnvironment()` and `isInDevelopmentEnvironment()` methods on `ExternalSessionConfiguration` to identify if the environment is configured for "Development" or "SIMULATION"
- Adds `isProctorless()` to the `Session` to identify if the session is managed by a Proctor
