### PR TITLE
Feature/pause exams in session

### DIFF
--- a/client/src/main/java/tds/session/PauseSessionResponse.java
+++ b/client/src/main/java/tds/session/PauseSessionResponse.java
@@ -14,18 +14,12 @@ public class PauseSessionResponse {
     private String status;
     private Instant dateChanged;
     private Instant dateEnded;
-    private List<UUID> examIds;
 
     public PauseSessionResponse(Session session) {
         this.sessionId = session.getId();
         this.status = session.getStatus();
         this.dateChanged = session.getDateChanged();
         this.dateEnded = session.getDateEnd();
-        this.examIds = new ArrayList<>();
-        // TODO:  DELETE - sample Exam IDs for response to caller.
-        for (int i = 0; i < 5; i++) {
-            this.examIds.add(UUID.randomUUID());
-        }
     }
 
     /**
@@ -54,15 +48,5 @@ public class PauseSessionResponse {
      */
     public Instant getDateEnded() {
         return dateEnded;
-    }
-
-    /**
-     * A side effect of pausing a {@link Session} is that all the associated Exams must also be paused.  This list will
-     * report on the Exams that were affected as a result of pausing this {@link Session}.
-     *
-     * @return A collection of Exam IDs that belong to the {@link Session} that was paused.
-     */
-    public List<UUID> getExamIds() {
-        return examIds;
     }
 }

--- a/service/src/main/java/tds/session/configuration/SessionApplicationConfiguration.java
+++ b/service/src/main/java/tds/session/configuration/SessionApplicationConfiguration.java
@@ -5,12 +5,14 @@ import org.springframework.context.annotation.Import;
 
 import tds.common.configuration.DataSourceConfiguration;
 import tds.common.configuration.JacksonObjectMapperConfiguration;
+import tds.common.configuration.RestTemplateConfiguration;
 import tds.common.web.advice.ExceptionAdvice;
 
 @Configuration
 @Import({
     ExceptionAdvice.class,
     DataSourceConfiguration.class,
+    RestTemplateConfiguration.class,
     JacksonObjectMapperConfiguration.class
 })
 public class SessionApplicationConfiguration {

--- a/service/src/main/java/tds/session/configuration/SessionServiceProperties.java
+++ b/service/src/main/java/tds/session/configuration/SessionServiceProperties.java
@@ -1,0 +1,34 @@
+package tds.session.configuration;
+
+import com.google.common.base.Preconditions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("session-service")
+public class SessionServiceProperties {
+    private String examUrl = "";
+
+    /**
+     * @return url for the exam microservice
+     */
+    public String getExamUrl() {
+        return examUrl;
+    }
+
+    public void setExamUrl(String examUrl) {
+        this.examUrl = removeTrailingSlash(Preconditions.checkNotNull(examUrl, "examUrl cannot be null"));
+    }
+
+    /**
+     * If there is a trailing slash at the end of a supplied URL, remove it.
+     *
+     * @param url The URL being trimmed
+     * @return The url without a trailing slash
+     */
+    private String removeTrailingSlash(String url) {
+        return url.endsWith("/")
+            ? url.substring(0, url.length() - 1)
+            : url;
+    }
+}

--- a/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
+++ b/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
@@ -73,7 +73,6 @@ class SessionRepositoryImpl implements SessionRepository {
         // Had to build the UTC Timestamp this way.  Using Timestamp utcTs = Timestamp.from(Instant.now()) would always
         // result in a Timestamp that reflected my local system clock settings.  Want to guarantee that dates/times are
         // always UTC, regardless of system clock.
-        // TODO:  Revisit injecting a clock/time zone dependency to enforce UTC time
         Timestamp utcTs = Timestamp.valueOf(LocalDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")));
 
         final SqlParameterSource parameters =

--- a/service/src/main/java/tds/session/services/ExamService.java
+++ b/service/src/main/java/tds/session/services/ExamService.java
@@ -1,0 +1,15 @@
+package tds.session.services;
+
+import java.util.UUID;
+
+/**
+ * Handles interaction with the exam service
+ */
+public interface ExamService {
+    /**
+     * Update the status of all exams in the specified {@link tds.session.Session} to "paused"
+     *
+     * @param sessionId The unique identifier of the session that has been closed
+     */
+    void pauseAllExamsInSession(UUID sessionId);
+}

--- a/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
@@ -1,0 +1,32 @@
+package tds.session.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+import tds.session.configuration.SessionServiceProperties;
+import tds.session.services.ExamService;
+
+@Service
+public class ExamServiceImpl implements ExamService {
+    private final RestTemplate restTemplate;
+    private final SessionServiceProperties sessionServiceProperties;
+
+    @Autowired
+    public ExamServiceImpl(RestTemplate restTemplate, SessionServiceProperties sessionServiceProperties) {
+        this.restTemplate = restTemplate;
+        this.sessionServiceProperties = sessionServiceProperties;
+    }
+
+    @Override
+    public void pauseAllExamsInSession(UUID sessionId) {
+        UriComponentsBuilder builder =
+            UriComponentsBuilder
+                .fromHttpUrl(String.format("%s/pause/%s", sessionServiceProperties.getExamUrl(), sessionId));
+
+        restTemplate.put(builder.toString(), null);
+    }
+}

--- a/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
@@ -27,6 +27,6 @@ public class ExamServiceImpl implements ExamService {
             UriComponentsBuilder
                 .fromHttpUrl(String.format("%s/pause/%s", sessionServiceProperties.getExamUrl(), sessionId));
 
-        restTemplate.put(builder.toString(), null);
+        restTemplate.put(builder.toUriString(), null);
     }
 }

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -11,18 +11,22 @@ import tds.session.Session;
 import tds.session.SessionAssessment;
 import tds.session.repositories.SessionAssessmentQueryRepository;
 import tds.session.repositories.SessionRepository;
+import tds.session.services.ExamService;
 import tds.session.services.SessionService;
 
 @Service
 class SessionServiceImpl implements SessionService {
     private final SessionRepository sessionRepository;
     private final SessionAssessmentQueryRepository sessionAssessmentQueryRepository;
+    private final ExamService examService;
 
     @Autowired
     public SessionServiceImpl(SessionRepository sessionRepository,
-                              SessionAssessmentQueryRepository sessionAssessmentQueryRepository) {
+                              SessionAssessmentQueryRepository sessionAssessmentQueryRepository,
+                              ExamService examService) {
         this.sessionRepository = sessionRepository;
         this.sessionAssessmentQueryRepository = sessionAssessmentQueryRepository;
+        this.examService = examService;
     }
 
     @Override
@@ -40,19 +44,14 @@ class SessionServiceImpl implements SessionService {
         Session session = sessionOptional.get();
         PauseSessionResponse pauseSessionResponse;
 
-        // if session is not open, it does not need to be paused, so return.
-        // TODO:  This condition might be over-simplified
+        // if session is not open it does not need to be paused, so return.
         if (!session.isOpen()) {
-            // TODO:  Collect all Exams associated w/the Session
-            //pauseSessionResponse.setExamIds(examIds);
             pauseSessionResponse = new PauseSessionResponse(session);
             return Optional.of(pauseSessionResponse);
         }
 
-        // TODO:  Call pause exam for each Exam in session and set affected examIds list on response object
-        // pauseSessionResponse.setExamIds();
+        examService.pauseAllExamsInSession(sessionId);
 
-        // Pause the Session
         sessionRepository.pause(sessionId, newStatus);
 
         // TODO:  Add call to create audit record that indicates the session is paused.

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -14,3 +14,5 @@ server.undertow.worker-threads=512
 server.undertow.direct-buffers=true
 
 #logging.level.org.springframework=DEBUG
+
+session-service.exam-url=

--- a/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
@@ -1,0 +1,44 @@
+package tds.session.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.UUID;
+
+import tds.session.configuration.SessionServiceProperties;
+import tds.session.services.ExamService;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamServiceImplTest {
+    private static final String BASE_URL = "http://localhost:8080/session";
+
+    private ExamService examService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Before
+    public void setUp() {
+        SessionServiceProperties sessionServiceProperties = new SessionServiceProperties();
+        sessionServiceProperties.setExamUrl(BASE_URL);
+        examService = new ExamServiceImpl(restTemplate, sessionServiceProperties);
+    }
+
+    @Test
+    public void shouldPauseAllExamsInASession() {
+        UUID sessionId = UUID.randomUUID();
+        String url = String.format("%s/pause/%s", BASE_URL, sessionId);
+        doNothing().when(restTemplate).put(url, null);
+
+        examService.pauseAllExamsInSession(sessionId);
+
+        verify(restTemplate).put(url, null);
+    }
+}

--- a/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import tds.session.configuration.SessionServiceProperties;
 import tds.session.services.ExamService;
 
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,7 +34,6 @@ public class ExamServiceImplTest {
     public void shouldPauseAllExamsInASession() {
         UUID sessionId = UUID.randomUUID();
         String url = String.format("%s/pause/%s", BASE_URL, sessionId);
-        doNothing().when(restTemplate).put(url, null);
 
         examService.pauseAllExamsInSession(sessionId);
 

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -1,22 +1,30 @@
 package tds.session.services.impl;
 
+import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import java.util.Optional;
 import java.util.UUID;
 
+import tds.session.PauseSessionResponse;
 import tds.session.Session;
 import tds.session.SessionAssessment;
 import tds.session.repositories.SessionAssessmentQueryRepository;
 import tds.session.repositories.SessionRepository;
+import tds.session.services.ExamService;
 import tds.session.services.SessionService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,9 +38,12 @@ public class SessionServiceImplTest {
     @Mock
     private SessionAssessmentQueryRepository mockSessionAssessmentQueryRepository;
 
+    @Mock
+    private ExamService mockExamService;
+
     @Before
     public void setUp() {
-        service = new SessionServiceImpl(mockSessionRepository, mockSessionAssessmentQueryRepository);
+        service = new SessionServiceImpl(mockSessionRepository, mockSessionAssessmentQueryRepository, mockExamService);
     }
 
     @After
@@ -76,5 +87,67 @@ public class SessionServiceImplTest {
         verify(mockSessionAssessmentQueryRepository).findSessionAssessment(sessionId, "(SBAC) 3 ELA 2015 - 2016");
 
         assertThat(maybeSessionAssessment).isPresent();
+    }
+
+    @Test
+    public void shouldPauseAllExamsInSession() {
+        Session mockOpenSession = new Session.Builder()
+            .withId(UUID.randomUUID())
+            .withStatus("open")
+            .withDateEnd(Instant.now().plus(600000))
+            .build();
+
+        // What the session will look like after mockSessionRepository.pause() is called
+        Session mockUpdatedSession = new Session.Builder()
+            .withId(mockOpenSession.getId())
+            .withStatus("closed")
+            .withDateChanged(Instant.now().plus(750000))
+            .withDateEnd(Instant.now().plus(750000))
+            .build();
+
+        when(mockSessionRepository.findSessionById(mockOpenSession.getId()))
+            .thenReturn(Optional.of(mockOpenSession))
+            .thenReturn(Optional.of(mockUpdatedSession));
+        doNothing().when(mockSessionRepository).pause(mockOpenSession.getId(), "closed");
+        doNothing().when(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
+
+        Optional<PauseSessionResponse> response = service.pause(mockOpenSession.getId(), "closed");
+
+        verify(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
+        verify(mockSessionRepository).pause(mockOpenSession.getId(), "closed");
+        verify(mockSessionRepository, times(2)).findSessionById(mockOpenSession.getId());
+
+        assertThat(response).isPresent();
+        PauseSessionResponse pauseSessionResponse = response.get();
+        assertThat(pauseSessionResponse.getStatus()).isEqualTo(mockUpdatedSession.getStatus());
+        assertThat(pauseSessionResponse.getSessionId()).isEqualTo(mockUpdatedSession.getId());
+        assertThat(pauseSessionResponse.getDateChanged()).isNotNull();
+        assertThat(pauseSessionResponse.getDateEnded()).isNotNull();
+    }
+
+    @Test
+    public void shouldNotCallExamServiceToPauseExamsOnAClosedSession() {
+        Session mockClosedSession = new Session.Builder()
+            .withId(UUID.randomUUID())
+            .withStatus("closed")
+            .withDateChanged(Instant.now().minus(600000))
+            .withDateEnd(Instant.now().minus(600000))
+            .build();
+
+        when(mockSessionRepository.findSessionById(mockClosedSession.getId())).thenReturn(Optional.of(mockClosedSession));
+        doNothing().when(mockExamService).pauseAllExamsInSession(mockClosedSession.getId());
+
+        Optional<PauseSessionResponse> response = service.pause(mockClosedSession.getId(), "paused");
+
+        verify(mockExamService, times(0)).pauseAllExamsInSession(mockClosedSession.getId());
+        verify(mockSessionRepository, times(0)).pause(mockClosedSession.getId(), "paused");
+        verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
+
+        assertThat(response).isPresent();
+        PauseSessionResponse pauseSessionResponse = response.get();
+        assertThat(pauseSessionResponse.getStatus()).isEqualTo("closed");
+        assertThat(pauseSessionResponse.getSessionId()).isEqualTo(mockClosedSession.getId());
+        assertThat(pauseSessionResponse.getDateChanged()).isEqualTo(mockClosedSession.getDateChanged());
+        assertThat(pauseSessionResponse.getDateEnded()).isEqualTo(mockClosedSession.getDateEnd());
     }
 }

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -78,18 +78,18 @@ public class SessionControllerIntegrationTests {
 
         Session session = new Session.Builder()
             .withId(id)
-            .withStatus("paused")
+            .withStatus("closed")
             .withClientName("SBAC_PT")
             .build();
 
-        when(mockSessionService.pause(id, "paused")).thenReturn(Optional.of(new PauseSessionResponse(session)));
+        when(mockSessionService.pause(id, "closed")).thenReturn(Optional.of(new PauseSessionResponse(session)));
 
         http.perform(put(new URI(String.format("/sessions/%s/pause", session.getId())))
-            .content("paused")
+            .content("closed")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("sessionId", is(session.getId().toString())))
-            .andExpect(jsonPath("status", is("paused")));
+            .andExpect(jsonPath("status", is("closed")));
     }
 
     @Test

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerTest.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerTest.java
@@ -73,7 +73,7 @@ public class SessionControllerTest {
     @Test
     public void shouldPauseSession() {
         final UUID sessionId = UUID.randomUUID();
-        final String newStatus = "paused";
+        final String newStatus = "closed";
         final Instant dateChanged = Instant.now();
         Session session = new Session.Builder()
             .withId(sessionId)
@@ -88,7 +88,6 @@ public class SessionControllerTest {
         verify(mockSessionService).pause(sessionId, newStatus);
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(responseEntity.getBody().getExamIds()).isEqualTo(pauseSessionResponse.getExamIds());
         assertThat(responseEntity.getBody().getStatus()).isEqualTo(newStatus);
         assertThat(responseEntity.getBody().getDateChanged()).isEqualTo(dateChanged);
         assertThat(responseEntity.getHeaders().getLocation().toString()).isEqualTo("http://localhost/sessions/" + sessionId);
@@ -97,8 +96,8 @@ public class SessionControllerTest {
     @Test(expected = NotFoundException.class)
     public void shouldThrowNotFoundIfSessionCannotBeFoundWhenPausingSession() {
         UUID sessionId = UUID.randomUUID();
-        when(mockSessionService.pause(sessionId, "paused")).thenReturn(Optional.empty());
-        controller.pause(sessionId, "paused");
+        when(mockSessionService.pause(sessionId, "closed")).thenReturn(Optional.empty());
+        controller.pause(sessionId, "closed");
     }
 
     @Test(expected = NotFoundException.class)

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -11,3 +11,5 @@ server.undertow.buffers-per-region=20
 server.undertow.io-threads=64
 server.undertow.worker-threads=512
 server.undertow.direct-buffers=true
+
+session-service.exam-url=


### PR DESCRIPTION
Update the `pause` method to call the Exam microservice and pause all the exams that are members of the session being paused.