### PR TITLE
Feature/pause exams in session

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -40,6 +40,10 @@
             <artifactId>joda-time</artifactId>
             <version>${joda-time.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/client/src/main/java/tds/session/PauseSessionRequest.java
+++ b/client/src/main/java/tds/session/PauseSessionRequest.java
@@ -1,0 +1,26 @@
+package tds.session;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.UUID;
+
+/**
+ * Data for requesting to pause a {@link tds.session.Session}
+ */
+public class PauseSessionRequest {
+    private UUID browserKey;
+    private long proctorId;
+
+    public PauseSessionRequest(@JsonProperty("proctorId") long proctorId, @JsonProperty("browserKey") UUID browserKey) {
+        this.proctorId = proctorId;
+        this.browserKey = browserKey;
+    }
+
+    public UUID getBrowserKey() {
+        return browserKey;
+    }
+
+    public long getProctorId() {
+        return proctorId;
+    }
+}

--- a/client/src/main/java/tds/session/PauseSessionResponse.java
+++ b/client/src/main/java/tds/session/PauseSessionResponse.java
@@ -14,18 +14,12 @@ public class PauseSessionResponse {
     private String status;
     private Instant dateChanged;
     private Instant dateEnded;
-    private List<UUID> examIds;
 
     public PauseSessionResponse(Session session) {
         this.sessionId = session.getId();
         this.status = session.getStatus();
         this.dateChanged = session.getDateChanged();
         this.dateEnded = session.getDateEnd();
-        this.examIds = new ArrayList<>();
-        // TODO:  DELETE - sample Exam IDs for response to caller.
-        for (int i = 0; i < 5; i++) {
-            this.examIds.add(UUID.randomUUID());
-        }
     }
 
     /**
@@ -54,15 +48,5 @@ public class PauseSessionResponse {
      */
     public Instant getDateEnded() {
         return dateEnded;
-    }
-
-    /**
-     * A side effect of pausing a {@link Session} is that all the associated Exams must also be paused.  This list will
-     * report on the Exams that were affected as a result of pausing this {@link Session}.
-     *
-     * @return A collection of Exam IDs that belong to the {@link Session} that was paused.
-     */
-    public List<UUID> getExamIds() {
-        return examIds;
     }
 }

--- a/client/src/main/java/tds/session/error/ValidationErrorCode.java
+++ b/client/src/main/java/tds/session/error/ValidationErrorCode.java
@@ -1,0 +1,8 @@
+package tds.session.error;
+
+
+public class ValidationErrorCode {
+    public static final String PAUSE_SESSION_IS_CLOSED = "sessionClosed";
+    public static final String PAUSE_SESSION_OWNED_BY_DIFFERENT_PROCTOR = "ownedByDifferentProctor";
+    public static final String PAUSE_SESSION_ACCESS_VIOLATION = "accessViolation";
+}

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <tds.session.client>0.0.1-SNAPSHOT</tds.session.client>
-        <tds.common>0.0.1-SNAPSHOT</tds.common>
+        <tds.session.client.version>0.0.1-SNAPSHOT</tds.session.client.version>
+        <tds.common.version>0.0.1-SNAPSHOT</tds.common.version>
 
         <unit-tests.skip>false</unit-tests.skip>
         <integration-tests.skip>true</integration-tests.skip>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,16 +17,21 @@
         <version>0.0.1-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <java.version>1.8</java.version>
+    </properties>
+
+
     <dependencies>
         <dependency>
             <groupId>org.opentestsystem.session</groupId>
             <artifactId>tds-session-client</artifactId>
-            <version>${tds.session.client}</version>
+            <version>${tds.session.client.version}</version>
         </dependency>
         <dependency>
             <groupId>org.opentestsystem.common</groupId>
             <artifactId>tds-common</artifactId>
-            <version>${tds.common}</version>
+            <version>${tds.common.version}</version>
         </dependency>
 
         <!-- Spring dependencies -->
@@ -138,7 +143,7 @@
         <dependency>
             <groupId>org.opentestsystem.common</groupId>
             <artifactId>tds-common-legacy</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>${tds.common.version}</version>
         </dependency>
     </dependencies>
 
@@ -202,15 +207,6 @@
                             <include>${project.build.finalName}.jar</include>
                         </resource>
                     </resources>
-                </configuration>
-            </plugin>
-
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -134,6 +134,12 @@
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.opentestsystem.common</groupId>
+            <artifactId>tds-common-legacy</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/service/src/main/java/tds/session/configuration/SessionApplicationConfiguration.java
+++ b/service/src/main/java/tds/session/configuration/SessionApplicationConfiguration.java
@@ -5,12 +5,14 @@ import org.springframework.context.annotation.Import;
 
 import tds.common.configuration.DataSourceConfiguration;
 import tds.common.configuration.JacksonObjectMapperConfiguration;
+import tds.common.configuration.RestTemplateConfiguration;
 import tds.common.web.advice.ExceptionAdvice;
 
 @Configuration
 @Import({
     ExceptionAdvice.class,
     DataSourceConfiguration.class,
+    RestTemplateConfiguration.class,
     JacksonObjectMapperConfiguration.class
 })
 public class SessionApplicationConfiguration {

--- a/service/src/main/java/tds/session/configuration/SessionServiceProperties.java
+++ b/service/src/main/java/tds/session/configuration/SessionServiceProperties.java
@@ -1,0 +1,34 @@
+package tds.session.configuration;
+
+import com.google.common.base.Preconditions;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties("session-service")
+public class SessionServiceProperties {
+    private String examUrl = "";
+
+    /**
+     * @return url for the exam microservice
+     */
+    public String getExamUrl() {
+        return examUrl;
+    }
+
+    public void setExamUrl(String examUrl) {
+        this.examUrl = removeTrailingSlash(Preconditions.checkNotNull(examUrl, "examUrl cannot be null"));
+    }
+
+    /**
+     * If there is a trailing slash at the end of a supplied URL, remove it.
+     *
+     * @param url The URL being trimmed
+     * @return The url without a trailing slash
+     */
+    private String removeTrailingSlash(String url) {
+        return url.endsWith("/")
+            ? url.substring(0, url.length() - 1)
+            : url;
+    }
+}

--- a/service/src/main/java/tds/session/configuration/SessionServiceProperties.java
+++ b/service/src/main/java/tds/session/configuration/SessionServiceProperties.java
@@ -1,8 +1,9 @@
 package tds.session.configuration;
 
-import com.google.common.base.Preconditions;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+
+import tds.common.web.utils.UrlUtils;
 
 @Component
 @ConfigurationProperties("session-service")
@@ -17,18 +18,6 @@ public class SessionServiceProperties {
     }
 
     public void setExamUrl(String examUrl) {
-        this.examUrl = removeTrailingSlash(Preconditions.checkNotNull(examUrl, "examUrl cannot be null"));
-    }
-
-    /**
-     * If there is a trailing slash at the end of a supplied URL, remove it.
-     *
-     * @param url The URL being trimmed
-     * @return The url without a trailing slash
-     */
-    private String removeTrailingSlash(String url) {
-        return url.endsWith("/")
-            ? url.substring(0, url.length() - 1)
-            : url;
+        this.examUrl = UrlUtils.removeTrailingSlash(examUrl);
     }
 }

--- a/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
+++ b/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
@@ -73,7 +73,6 @@ class SessionRepositoryImpl implements SessionRepository {
         // Had to build the UTC Timestamp this way.  Using Timestamp utcTs = Timestamp.from(Instant.now()) would always
         // result in a Timestamp that reflected my local system clock settings.  Want to guarantee that dates/times are
         // always UTC, regardless of system clock.
-        // TODO:  Revisit injecting a clock/time zone dependency to enforce UTC time
         Timestamp utcTs = Timestamp.valueOf(LocalDateTime.ofInstant(Instant.now(), ZoneId.of("UTC")));
 
         final SqlParameterSource parameters =

--- a/service/src/main/java/tds/session/services/ExamService.java
+++ b/service/src/main/java/tds/session/services/ExamService.java
@@ -1,0 +1,15 @@
+package tds.session.services;
+
+import java.util.UUID;
+
+/**
+ * Handles interaction with the exam service
+ */
+public interface ExamService {
+    /**
+     * Update the status of all exams in the specified {@link tds.session.Session} to "paused"
+     *
+     * @param sessionId The unique identifier of the session that has been closed
+     */
+    void pauseAllExamsInSession(UUID sessionId);
+}

--- a/service/src/main/java/tds/session/services/SessionService.java
+++ b/service/src/main/java/tds/session/services/SessionService.java
@@ -3,6 +3,8 @@ package tds.session.services;
 import java.util.Optional;
 import java.util.UUID;
 
+import tds.common.Response;
+import tds.session.PauseSessionRequest;
 import tds.session.PauseSessionResponse;
 import tds.session.Session;
 import tds.session.SessionAssessment;
@@ -27,10 +29,10 @@ public interface SessionService {
      * considered "paused".
      * </p>
      *
-     * @param sessionId The id of the {@link Session} to pause
-     * @param newStatus A description of why the {@link Session} is being paused
+     * @param sessionId he session id of {@link tds.session.Session} should be paused
+     * @param request   The proctor id and browser key to identify the requester
      */
-    Optional<PauseSessionResponse> pause(UUID sessionId, String newStatus);
+    Response<PauseSessionResponse> pause(UUID sessionId, PauseSessionRequest request);
 
     /**
      * Finds the associated {@link tds.session.SessionAssessment}

--- a/service/src/main/java/tds/session/services/SessionService.java
+++ b/service/src/main/java/tds/session/services/SessionService.java
@@ -29,7 +29,7 @@ public interface SessionService {
      * considered "paused".
      * </p>
      *
-     * @param sessionId he session id of {@link tds.session.Session} should be paused
+     * @param sessionId the session id of {@link tds.session.Session} should be paused
      * @param request   The proctor id and browser key to identify the requester
      */
     Response<PauseSessionResponse> pause(UUID sessionId, PauseSessionRequest request);

--- a/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
@@ -1,0 +1,32 @@
+package tds.session.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.UUID;
+
+import tds.session.configuration.SessionServiceProperties;
+import tds.session.services.ExamService;
+
+@Service
+public class ExamServiceImpl implements ExamService {
+    private final RestTemplate restTemplate;
+    private final SessionServiceProperties sessionServiceProperties;
+
+    @Autowired
+    public ExamServiceImpl(RestTemplate restTemplate, SessionServiceProperties sessionServiceProperties) {
+        this.restTemplate = restTemplate;
+        this.sessionServiceProperties = sessionServiceProperties;
+    }
+
+    @Override
+    public void pauseAllExamsInSession(UUID sessionId) {
+        UriComponentsBuilder builder =
+            UriComponentsBuilder
+                .fromHttpUrl(String.format("%s/pause/%s", sessionServiceProperties.getExamUrl(), sessionId));
+
+        restTemplate.put(builder.toString(), null);
+    }
+}

--- a/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
@@ -27,6 +27,6 @@ public class ExamServiceImpl implements ExamService {
             UriComponentsBuilder
                 .fromHttpUrl(String.format("%s/pause/%s", sessionServiceProperties.getExamUrl(), sessionId));
 
-        restTemplate.put(builder.toString(), null);
+        restTemplate.put(builder.toUriString(), null);
     }
 }

--- a/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/ExamServiceImpl.java
@@ -11,7 +11,7 @@ import tds.session.configuration.SessionServiceProperties;
 import tds.session.services.ExamService;
 
 @Service
-public class ExamServiceImpl implements ExamService {
+class ExamServiceImpl implements ExamService {
     private final RestTemplate restTemplate;
     private final SessionServiceProperties sessionServiceProperties;
 

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -6,9 +6,14 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 import java.util.UUID;
 
+import tds.common.Response;
+import tds.common.ValidationError;
+import tds.common.web.exceptions.NotFoundException;
+import tds.session.PauseSessionRequest;
 import tds.session.PauseSessionResponse;
 import tds.session.Session;
 import tds.session.SessionAssessment;
+import tds.session.error.ValidationErrorCode;
 import tds.session.repositories.SessionAssessmentQueryRepository;
 import tds.session.repositories.SessionRepository;
 import tds.session.services.ExamService;
@@ -35,33 +40,55 @@ class SessionServiceImpl implements SessionService {
     }
 
     @Override
-    public Optional<PauseSessionResponse> pause(final UUID sessionId, final String newStatus) {
-        final Optional<Session> sessionOptional = sessionRepository.findSessionById(sessionId);
-        if (!sessionOptional.isPresent()) {
-            return Optional.empty();
-        }
+    public Response<PauseSessionResponse> pause(final UUID sessionId, PauseSessionRequest request) {
+        final Session session = sessionRepository.findSessionById(sessionId)
+            .orElseThrow(() -> new NotFoundException(String.format("Could not find session for session id %s", sessionId)));
 
-        Session session = sessionOptional.get();
-        PauseSessionResponse pauseSessionResponse;
-
-        // if session is not open it does not need to be paused, so return.
-        if (!session.isOpen()) {
-            pauseSessionResponse = new PauseSessionResponse(session);
-            return Optional.of(pauseSessionResponse);
+        Optional<ValidationError> maybeValidationError = verifySessionCanBePaused(session, request);
+        if (maybeValidationError.isPresent()) {
+            return new Response<PauseSessionResponse>(maybeValidationError.get());
         }
 
         examService.pauseAllExamsInSession(sessionId);
+        sessionRepository.pause(sessionId, "closed");
 
-        sessionRepository.pause(sessionId, newStatus);
+        Session updatedSession = sessionRepository.findSessionById(sessionId)
+            .orElseThrow(() -> new NotFoundException(String.format("Could not find session for session id %s", sessionId)));
 
-        // TODO:  Add call to create audit record that indicates the session is paused.
-        Session updatedSession = sessionRepository.findSessionById(sessionId).get(); // we know the session exists already
-        pauseSessionResponse = new PauseSessionResponse(updatedSession);
-        return Optional.of(pauseSessionResponse);
+        return new Response<>(new PauseSessionResponse(updatedSession));
     }
 
     @Override
     public Optional<SessionAssessment> findSessionAssessment(UUID sessionId, String assessmentKey) {
         return sessionAssessmentQueryRepository.findSessionAssessment(sessionId, assessmentKey);
+    }
+
+    /**
+     * Determine if the requested {@link tds.session.Session} can be paused.
+     *
+     * @param session The session being paused
+     * @param request The request submitted to pause the session
+     * @return {@code Optional.empty()} if the session can be paused, otherwise a {@link tds.common.ValidationError}
+     * that describes why the session cannot be paused.
+     */
+    private Optional<ValidationError> verifySessionCanBePaused(Session session, PauseSessionRequest request) {
+        // CommonDLL.ValidateProctorSession_FN (@ line 1727) rules:
+
+        // RULE:  The session must be open
+        if (!session.isOpen()) {
+            return Optional.of(new ValidationError(ValidationErrorCode.PAUSE_SESSION_IS_CLOSED, "The session is closed"));
+        }
+
+        // RULE:  The Proctor making the request must own the session
+        if (session.getProctorId() != request.getProctorId()) {
+            return Optional.of(new ValidationError(ValidationErrorCode.PAUSE_SESSION_OWNED_BY_DIFFERENT_PROCTOR, "The session is not owned by this proctor"));
+        }
+
+        // RULE:  The requester's browser key must match the session's browser key
+        if (!session.getBrowserKey().equals(request.getBrowserKey())) {
+            return Optional.of(new ValidationError(ValidationErrorCode.PAUSE_SESSION_ACCESS_VIOLATION, "Unauthorized session access"));
+        }
+
+        return Optional.empty();
     }
 }

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -53,7 +53,7 @@ class SessionServiceImpl implements SessionService {
         sessionRepository.pause(sessionId, "closed");
 
         Session updatedSession = sessionRepository.findSessionById(sessionId)
-            .orElseThrow(() -> new NotFoundException(String.format("Could not find session for session id %s", sessionId)));
+            .orElseThrow(() -> new IllegalStateException(String.format("Could not find session that was just closed for session id %s", sessionId)));
 
         return new Response<>(new PauseSessionResponse(updatedSession));
     }

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -11,18 +11,22 @@ import tds.session.Session;
 import tds.session.SessionAssessment;
 import tds.session.repositories.SessionAssessmentQueryRepository;
 import tds.session.repositories.SessionRepository;
+import tds.session.services.ExamService;
 import tds.session.services.SessionService;
 
 @Service
 class SessionServiceImpl implements SessionService {
     private final SessionRepository sessionRepository;
     private final SessionAssessmentQueryRepository sessionAssessmentQueryRepository;
+    private final ExamService examService;
 
     @Autowired
     public SessionServiceImpl(SessionRepository sessionRepository,
-                              SessionAssessmentQueryRepository sessionAssessmentQueryRepository) {
+                              SessionAssessmentQueryRepository sessionAssessmentQueryRepository,
+                              ExamService examService) {
         this.sessionRepository = sessionRepository;
         this.sessionAssessmentQueryRepository = sessionAssessmentQueryRepository;
+        this.examService = examService;
     }
 
     @Override
@@ -40,19 +44,14 @@ class SessionServiceImpl implements SessionService {
         Session session = sessionOptional.get();
         PauseSessionResponse pauseSessionResponse;
 
-        // if session is not open, it does not need to be paused, so return.
-        // TODO:  This condition might be over-simplified
+        // if session is not open it does not need to be paused, so return.
         if (!session.isOpen()) {
-            // TODO:  Collect all Exams associated w/the Session
-            //pauseSessionResponse.setExamIds(examIds);
             pauseSessionResponse = new PauseSessionResponse(session);
             return Optional.of(pauseSessionResponse);
         }
 
-        // TODO:  Call pause exam for each Exam in session and set affected examIds list on response object
-        // pauseSessionResponse.setExamIds();
+        examService.pauseAllExamsInSession(sessionId);
 
-        // Pause the Session
         sessionRepository.pause(sessionId, newStatus);
 
         // TODO:  Add call to create audit record that indicates the session is paused.

--- a/service/src/main/java/tds/session/web/endpoints/SessionController.java
+++ b/service/src/main/java/tds/session/web/endpoints/SessionController.java
@@ -53,7 +53,7 @@ class SessionController {
     ResponseEntity<Response<PauseSessionResponse>> pause(@PathVariable final UUID sessionId, @RequestBody final PauseSessionRequest request) {
         final Response<PauseSessionResponse> response = sessionService.pause(sessionId, request);
 
-        if (response.getErrors().length > 0) {
+        if (response.hasErrors()) {
             return new ResponseEntity<>(response, HttpStatus.UNPROCESSABLE_ENTITY);
         }
 

--- a/service/src/main/resources/application.properties
+++ b/service/src/main/resources/application.properties
@@ -14,3 +14,5 @@ server.undertow.worker-threads=512
 server.undertow.direct-buffers=true
 
 #logging.level.org.springframework=DEBUG
+
+session-service.exam-url=

--- a/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
@@ -1,0 +1,44 @@
+package tds.session.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.UUID;
+
+import tds.session.configuration.SessionServiceProperties;
+import tds.session.services.ExamService;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamServiceImplTest {
+    private static final String BASE_URL = "http://localhost:8080/session";
+
+    private ExamService examService;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Before
+    public void setUp() {
+        SessionServiceProperties sessionServiceProperties = new SessionServiceProperties();
+        sessionServiceProperties.setExamUrl(BASE_URL);
+        examService = new ExamServiceImpl(restTemplate, sessionServiceProperties);
+    }
+
+    @Test
+    public void shouldPauseAllExamsInASession() {
+        UUID sessionId = UUID.randomUUID();
+        String url = String.format("%s/pause/%s", BASE_URL, sessionId);
+        doNothing().when(restTemplate).put(url, null);
+
+        examService.pauseAllExamsInSession(sessionId);
+
+        verify(restTemplate).put(url, null);
+    }
+}

--- a/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/ExamServiceImplTest.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import tds.session.configuration.SessionServiceProperties;
 import tds.session.services.ExamService;
 
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -35,7 +34,6 @@ public class ExamServiceImplTest {
     public void shouldPauseAllExamsInASession() {
         UUID sessionId = UUID.randomUUID();
         String url = String.format("%s/pause/%s", BASE_URL, sessionId);
-        doNothing().when(restTemplate).put(url, null);
 
         examService.pauseAllExamsInSession(sessionId);
 

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -27,6 +27,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -153,13 +155,12 @@ public class SessionServiceImplTest {
         PauseSessionRequest request = new PauseSessionRequest(proctorId, browserKey);
 
         when(mockSessionRepository.findSessionById(mockClosedSession.getId())).thenReturn(Optional.of(mockClosedSession));
-        doNothing().when(mockExamService).pauseAllExamsInSession(mockClosedSession.getId());
 
         Response<PauseSessionResponse> response = service.pause(sessionId, request);
 
-        verify(mockExamService, times(0)).pauseAllExamsInSession(mockClosedSession.getId());
-        verify(mockSessionRepository, times(0)).pause(mockClosedSession.getId(), "closed");
+        verifyZeroInteractions(mockExamService);
         verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
+        verifyNoMoreInteractions(mockSessionRepository);
 
         assertThat(response.getData().isPresent()).isFalse();
         assertThat(response.getErrors()).hasSize(1);
@@ -184,13 +185,12 @@ public class SessionServiceImplTest {
         PauseSessionRequest request = new PauseSessionRequest(proctorId, browserKey);
 
         when(mockSessionRepository.findSessionById(mockClosedSession.getId())).thenReturn(Optional.of(mockClosedSession));
-        doNothing().when(mockExamService).pauseAllExamsInSession(mockClosedSession.getId());
 
         Response<PauseSessionResponse> response = service.pause(sessionId, request);
 
-        verify(mockExamService, times(0)).pauseAllExamsInSession(mockClosedSession.getId());
-        verify(mockSessionRepository, times(0)).pause(mockClosedSession.getId(), "closed");
+        verifyZeroInteractions(mockExamService);
         verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
+        verifyNoMoreInteractions(mockSessionRepository);
 
         assertThat(response.getData().isPresent()).isFalse();
         assertThat(response.getErrors()).hasSize(1);

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -1,22 +1,30 @@
 package tds.session.services.impl;
 
+import org.joda.time.Instant;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
 
 import java.util.Optional;
 import java.util.UUID;
 
+import tds.session.PauseSessionResponse;
 import tds.session.Session;
 import tds.session.SessionAssessment;
 import tds.session.repositories.SessionAssessmentQueryRepository;
 import tds.session.repositories.SessionRepository;
+import tds.session.services.ExamService;
 import tds.session.services.SessionService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -30,9 +38,12 @@ public class SessionServiceImplTest {
     @Mock
     private SessionAssessmentQueryRepository mockSessionAssessmentQueryRepository;
 
+    @Mock
+    private ExamService mockExamService;
+
     @Before
     public void setUp() {
-        service = new SessionServiceImpl(mockSessionRepository, mockSessionAssessmentQueryRepository);
+        service = new SessionServiceImpl(mockSessionRepository, mockSessionAssessmentQueryRepository, mockExamService);
     }
 
     @After
@@ -76,5 +87,67 @@ public class SessionServiceImplTest {
         verify(mockSessionAssessmentQueryRepository).findSessionAssessment(sessionId, "(SBAC) 3 ELA 2015 - 2016");
 
         assertThat(maybeSessionAssessment).isPresent();
+    }
+
+    @Test
+    public void shouldPauseAllExamsInSession() {
+        Session mockOpenSession = new Session.Builder()
+            .withId(UUID.randomUUID())
+            .withStatus("open")
+            .withDateEnd(Instant.now().plus(600000))
+            .build();
+
+        // What the session will look like after mockSessionRepository.pause() is called
+        Session mockUpdatedSession = new Session.Builder()
+            .withId(mockOpenSession.getId())
+            .withStatus("closed")
+            .withDateChanged(Instant.now().plus(750000))
+            .withDateEnd(Instant.now().plus(750000))
+            .build();
+
+        when(mockSessionRepository.findSessionById(mockOpenSession.getId()))
+            .thenReturn(Optional.of(mockOpenSession))
+            .thenReturn(Optional.of(mockUpdatedSession));
+        doNothing().when(mockSessionRepository).pause(mockOpenSession.getId(), "closed");
+        doNothing().when(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
+
+        Optional<PauseSessionResponse> response = service.pause(mockOpenSession.getId(), "closed");
+
+        verify(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
+        verify(mockSessionRepository).pause(mockOpenSession.getId(), "closed");
+        verify(mockSessionRepository, times(2)).findSessionById(mockOpenSession.getId());
+
+        assertThat(response).isPresent();
+        PauseSessionResponse pauseSessionResponse = response.get();
+        assertThat(pauseSessionResponse.getStatus()).isEqualTo(mockUpdatedSession.getStatus());
+        assertThat(pauseSessionResponse.getSessionId()).isEqualTo(mockUpdatedSession.getId());
+        assertThat(pauseSessionResponse.getDateChanged()).isNotNull();
+        assertThat(pauseSessionResponse.getDateEnded()).isNotNull();
+    }
+
+    @Test
+    public void shouldNotCallExamServiceToPauseExamsOnAClosedSession() {
+        Session mockClosedSession = new Session.Builder()
+            .withId(UUID.randomUUID())
+            .withStatus("closed")
+            .withDateChanged(Instant.now().minus(600000))
+            .withDateEnd(Instant.now().minus(600000))
+            .build();
+
+        when(mockSessionRepository.findSessionById(mockClosedSession.getId())).thenReturn(Optional.of(mockClosedSession));
+        doNothing().when(mockExamService).pauseAllExamsInSession(mockClosedSession.getId());
+
+        Optional<PauseSessionResponse> response = service.pause(mockClosedSession.getId(), "paused");
+
+        verify(mockExamService, times(0)).pauseAllExamsInSession(mockClosedSession.getId());
+        verify(mockSessionRepository, times(0)).pause(mockClosedSession.getId(), "paused");
+        verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
+
+        assertThat(response).isPresent();
+        PauseSessionResponse pauseSessionResponse = response.get();
+        assertThat(pauseSessionResponse.getStatus()).isEqualTo("closed");
+        assertThat(pauseSessionResponse.getSessionId()).isEqualTo(mockClosedSession.getId());
+        assertThat(pauseSessionResponse.getDateChanged()).isEqualTo(mockClosedSession.getDateChanged());
+        assertThat(pauseSessionResponse.getDateEnded()).isEqualTo(mockClosedSession.getDateEnd());
     }
 }

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -1,5 +1,7 @@
 package tds.session.web.endpoints;
 
+import org.joda.time.Instant;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,13 +18,18 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.UUID;
 
+import tds.common.Response;
+import tds.common.ValidationError;
 import tds.common.web.advice.ExceptionAdvice;
+import tds.session.PauseSessionRequest;
 import tds.session.PauseSessionResponse;
 import tds.session.Session;
 import tds.session.SessionAssessment;
+import tds.session.error.ValidationErrorCode;
 import tds.session.services.SessionService;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -31,7 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(SessionController.class)
-@Import(ExceptionAdvice.class)
+@Import({ExceptionAdvice.class, tds.common.configuration.JacksonObjectMapperConfiguration.class})
 public class SessionControllerIntegrationTests {
     @Autowired
     private MockMvc http;
@@ -74,22 +81,66 @@ public class SessionControllerIntegrationTests {
 
     @Test
     public void shouldPauseASession() throws Exception {
-        UUID id = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        UUID browserKey = UUID.randomUUID();
+        long proctorId = 1L;
 
-        Session session = new Session.Builder()
-            .withId(id)
+        // What a session will look like after mockSessionService.pause() runs successfully
+        Session mockClosedSession = new Session.Builder()
+            .withId(sessionId)
             .withStatus("closed")
-            .withClientName("SBAC_PT")
+            .withBrowserKey(browserKey)
+            .withProctorId(proctorId)
+            .withDateChanged(Instant.now().plus(60000))
+            .withDateEnd(Instant.now().plus(60000))
             .build();
 
-        when(mockSessionService.pause(id, "closed")).thenReturn(Optional.of(new PauseSessionResponse(session)));
+        PauseSessionRequest request = new PauseSessionRequest(proctorId, browserKey);
+        Response<PauseSessionResponse> mockResponse = new Response<>(new PauseSessionResponse(mockClosedSession), new ValidationError[]{});
+        when(mockSessionService.pause(isA(UUID.class), isA(PauseSessionRequest.class))).thenReturn(mockResponse);
 
-        http.perform(put(new URI(String.format("/sessions/%s/pause", session.getId())))
-            .content("closed")
+        JSONObject requestJson = new JSONObject(request);
+
+        http.perform(put(new URI(String.format("/sessions/%s/pause", mockClosedSession.getId())))
+            .content(requestJson.toString())
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
-            .andExpect(jsonPath("sessionId", is(session.getId().toString())))
-            .andExpect(jsonPath("status", is("closed")));
+            .andExpect(jsonPath("errors").isEmpty())
+            .andExpect(jsonPath("data.sessionId", is(mockClosedSession.getId().toString())))
+            .andExpect(jsonPath("data.status", is("closed")))
+            .andExpect(jsonPath("data.dateChanged").exists())
+            .andExpect(jsonPath("data.dateEnded").exists());
+    }
+
+    @Test
+    public void shouldReturnErrorsWhenASessionCannotBePaused() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        UUID browserKey = UUID.randomUUID();
+        long proctorId = 1L;
+
+        Session mockOwnedByAnotherProctor = new Session.Builder()
+            .withId(sessionId)
+            .withStatus("open")
+            .withBrowserKey(browserKey)
+            .withProctorId(5L)
+            .withDateChanged(Instant.now().plus(60000))
+            .withDateEnd(Instant.now().plus(60000))
+            .build();
+
+        PauseSessionRequest mockRequest = new PauseSessionRequest(proctorId, browserKey);
+        ValidationError mockError = new ValidationError(ValidationErrorCode.PAUSE_SESSION_OWNED_BY_DIFFERENT_PROCTOR, "The session is not owned by this proctor");
+        Response<PauseSessionResponse> mockResponse = new Response<>(new PauseSessionResponse(mockOwnedByAnotherProctor), mockError);
+        when(mockSessionService.pause(isA(UUID.class), isA(PauseSessionRequest.class))).thenReturn(mockResponse);
+
+        JSONObject requestJson = new JSONObject(mockRequest);
+
+        http.perform(put(new URI(String.format("/sessions/%s/pause", mockOwnedByAnotherProctor.getId())))
+            .content(requestJson.toString())
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnprocessableEntity())
+            .andExpect(jsonPath("errors").isArray())
+            .andExpect(jsonPath("errors[0].code", is("ownedByDifferentProctor")))
+            .andExpect(jsonPath("errors[0].message", is("The session is not owned by this proctor")));
     }
 
     @Test

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 
 import tds.common.Response;
 import tds.common.ValidationError;
+import tds.common.configuration.JacksonObjectMapperConfiguration;
 import tds.common.web.advice.ExceptionAdvice;
 import tds.session.PauseSessionRequest;
 import tds.session.PauseSessionResponse;
@@ -38,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(SessionController.class)
-@Import({ExceptionAdvice.class, tds.common.configuration.JacksonObjectMapperConfiguration.class})
+@Import({ExceptionAdvice.class, JacksonObjectMapperConfiguration.class})
 public class SessionControllerIntegrationTests {
     @Autowired
     private MockMvc http;

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -78,18 +78,18 @@ public class SessionControllerIntegrationTests {
 
         Session session = new Session.Builder()
             .withId(id)
-            .withStatus("paused")
+            .withStatus("closed")
             .withClientName("SBAC_PT")
             .build();
 
-        when(mockSessionService.pause(id, "paused")).thenReturn(Optional.of(new PauseSessionResponse(session)));
+        when(mockSessionService.pause(id, "closed")).thenReturn(Optional.of(new PauseSessionResponse(session)));
 
         http.perform(put(new URI(String.format("/sessions/%s/pause", session.getId())))
-            .content("paused")
+            .content("closed")
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("sessionId", is(session.getId().toString())))
-            .andExpect(jsonPath("status", is("paused")));
+            .andExpect(jsonPath("status", is("closed")));
     }
 
     @Test

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerTest.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerTest.java
@@ -97,8 +97,8 @@ public class SessionControllerTest {
         PauseSessionResponse resultFromService = responseEntity.getBody().getData().get();
         assertThat(resultFromService.getSessionId()).isEqualTo(sessionId);
         assertThat(resultFromService.getStatus()).isEqualTo("closed");
-        assertThat(resultFromService.getDateEnded().getMillis()).isEqualTo(mockClosedResponse.getDateEnded().getMillis());
-        assertThat(resultFromService.getDateChanged().getMillis()).isEqualTo(mockClosedResponse.getDateEnded().getMillis());
+        assertThat(resultFromService.getDateEnded()).isEqualTo(mockClosedResponse.getDateEnded());
+        assertThat(resultFromService.getDateChanged()).isEqualTo(mockClosedResponse.getDateEnded());
         assertThat(responseEntity.getHeaders().getLocation().toString()).isEqualTo("http://localhost/sessions/" + sessionId);
     }
 

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerTest.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerTest.java
@@ -73,7 +73,7 @@ public class SessionControllerTest {
     @Test
     public void shouldPauseSession() {
         final UUID sessionId = UUID.randomUUID();
-        final String newStatus = "paused";
+        final String newStatus = "closed";
         final Instant dateChanged = Instant.now();
         Session session = new Session.Builder()
             .withId(sessionId)
@@ -88,7 +88,6 @@ public class SessionControllerTest {
         verify(mockSessionService).pause(sessionId, newStatus);
 
         assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(responseEntity.getBody().getExamIds()).isEqualTo(pauseSessionResponse.getExamIds());
         assertThat(responseEntity.getBody().getStatus()).isEqualTo(newStatus);
         assertThat(responseEntity.getBody().getDateChanged()).isEqualTo(dateChanged);
         assertThat(responseEntity.getHeaders().getLocation().toString()).isEqualTo("http://localhost/sessions/" + sessionId);
@@ -97,8 +96,8 @@ public class SessionControllerTest {
     @Test(expected = NotFoundException.class)
     public void shouldThrowNotFoundIfSessionCannotBeFoundWhenPausingSession() {
         UUID sessionId = UUID.randomUUID();
-        when(mockSessionService.pause(sessionId, "paused")).thenReturn(Optional.empty());
-        controller.pause(sessionId, "paused");
+        when(mockSessionService.pause(sessionId, "closed")).thenReturn(Optional.empty());
+        controller.pause(sessionId, "closed");
     }
 
     @Test(expected = NotFoundException.class)

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -11,3 +11,5 @@ server.undertow.buffers-per-region=20
 server.undertow.io-threads=64
 server.undertow.worker-threads=512
 server.undertow.direct-buffers=true
+
+session-service.exam-url=


### PR DESCRIPTION
TDS-382:
* Pause a session, which calls out to the exam service to pause all associated exams
* Added code to emulate the `CommonDLL.ValidateProctorSession_FN` rules for closing a session (session must be open, owned by same proctor and have same browser key)
