### PR TITLE
Externalize session-service properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,5 +34,6 @@
         <assertj.version>3.4.1</assertj.version>
         <mockito.version>1.10.19</mockito.version>
         <joda-time.version>2.9.5</joda-time.version>
+        <spring.cloud.config.version>1.2.2.RELEASE</spring.cloud.config.version>
     </properties>
 </project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -21,6 +21,17 @@
         <java.version>1.8</java.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-config</artifactId>
+                <version>${spring.cloud.config.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -35,6 +46,11 @@
         </dependency>
 
         <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-hateoas</artifactId>

--- a/service/src/main/docker/Dockerfile
+++ b/service/src/main/docker/Dockerfile
@@ -12,5 +12,6 @@ COPY docker-startup.sh docker-startup.sh
 COPY tds-session-service-0.0.1-SNAPSHOT.jar tds-session-service.jar
 
 RUN sh -c 'touch /tds-session-service.jar /docker-startup.sh'
+RUN apk --no-cache add curl
 
 ENTRYPOINT ["/docker-startup.sh"]

--- a/service/src/main/docker/docker-startup.sh
+++ b/service/src/main/docker/docker-startup.sh
@@ -6,19 +6,4 @@
 #
 #-----------------------------------------------------------------------------------------------------------------------
 
-java \
-    -Dspring.datasource.url="jdbc:mysql://${SESSION_DB_HOST}:${SESSION_DB_PORT}/${SESSION_DB_NAME}" \
-    -Dspring.datasource.username="${SESSION_DB_USER}" \
-    -Dspring.datasource.password="${SESSION_DB_PASSWORD}" \
-    -Dspring.datasource.type=com.zaxxer.hikari.HikariDataSource \
-    -Dspring.datasource.driver-class-name=com.mysql.jdbc.Driver \
-    -Dspring.datasource.testWhileIdle=true \
-    -Dspring.datasource.timeBetweenEvictionRunsMillis=60000 \
-    -Dspring.datasource.validationQuery="SELECT 1" \
-    -jar /tds-session-service.jar \
-    --server-port="8080" \
-    --server.undertow.buffer-size=16384 \
-    --server.undertow.buffers-per-region=20 \
-    --server.undertow.io-threads=64 \
-    --server.undertow.worker-threads=512 \
-    --server.undertow.direct-buffers=true \
+java -jar /tds-session-service.jar

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,0 +1,28 @@
+spring:
+  profiles: local-development
+  datasource:
+    url: ${sbac.jdbc.host}/session
+    username: ${sbac.jdbc.user}
+    password: ${sbac.jdbc.password}
+    type: com.zaxxer.hikari.HikariDataSource
+    driver-class-name: com.mysql.jdbc.Driver
+  mvc:
+    throw-exception-if-no-handler-found: true
+  resources:
+    add-mappings: false
+
+flyway:
+  enabled: false
+
+server:
+  port: 8082
+  undertow:
+    buffer-size: 16384
+    buffers-per-region: 20
+    io-threads: 64
+    worker-threads: 512
+    direct-buffers: true
+
+session-service:
+  #Assume we're also running a tds-exam-service in "local-development" mode
+  exam-url: http://localhost:8081

--- a/service/src/main/resources/bootstrap.yml
+++ b/service/src/main/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: tds-session-service
+  cloud:
+    config:
+      uri: ${CONFIG_SERVICE_URL:http://localhost:8888}
+      enabled: ${CONFIG_SERVICE_ENABLED:false}
+      fail-fast: ${CONFIG_SERVICE_ENABLED:false}

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -1,0 +1,29 @@
+spring:
+  datasource:
+    url: ${sbac.jdbc.host}/session
+    username: ${sbac.jdbc.user}
+    password: ${sbac.jdbc.password}
+    type: com.zaxxer.hikari.HikariDataSource
+    driver-class-name: com.mysql.jdbc.Driver
+  mvc:
+    throw-exception-if-no-handler-found: true
+  resources:
+    add-mappings: false
+
+flyway:
+  enabled: true
+  baseline-on-migrate: true
+  out-of-order: true
+
+server:
+  port: 8082
+  undertow:
+    buffer-size: 16384
+    buffers-per-region: 20
+    io-threads: 64
+    worker-threads: 512
+    direct-buffers: true
+
+session-service:
+  #Assume we're also running a tds-exam-service in "local-development" mode
+  exam-url: http://localhost:8081


### PR DESCRIPTION
Externalize configuration properties:
1. Remove properties from docker-container startup script
2. Add bootstrap.yml properties for connecting to a spring cloud config service
3. Add required maven dependencies
4. Add runtime application.yml with default properties and a local-development profile
5. Add test application.yml with default testing properties to allow running unit/integration tests with a local database