### PR TITLE
TDS-643: Add isPaused() method

### DIFF
--- a/client/src/main/java/tds/session/PauseSessionResponse.java
+++ b/client/src/main/java/tds/session/PauseSessionResponse.java
@@ -58,13 +58,12 @@ public class PauseSessionResponse {
      * Determine if the {@link tds.session.Session} is in a paused/closed state.
      * <p>
      *     A {@link tds.session.Session} can only be in an open or closed state.  Even though the method in legacy is
-     *     called "pauseSession", the act of pausing a session closes it.  The naming convention has been carried
-     *     forward from the legacy codebase.
+     *     called "pauseSession", the act of pausing a session closes it.
      * </p>
      *
      * @return True if the {@link tds.session.Session}'s status is "closed"; otherwise false.
      */
-    public boolean isPaused() {
+    public boolean isClosed() {
         return this.status.equalsIgnoreCase("closed");
     }
 }

--- a/client/src/main/java/tds/session/PauseSessionResponse.java
+++ b/client/src/main/java/tds/session/PauseSessionResponse.java
@@ -53,4 +53,18 @@ public class PauseSessionResponse {
     public Instant getDateEnded() {
         return dateEnded;
     }
+
+    /**
+     * Determine if the {@link tds.session.Session} is in a paused/closed state.
+     * <p>
+     *     A {@link tds.session.Session} can only be in an open or closed state.  Even though the method in legacy is
+     *     called "pauseSession", the act of pausing a session closes it.  The naming convention has been carried
+     *     forward from the legacy codebase.
+     * </p>
+     *
+     * @return True if the {@link tds.session.Session}'s status is "closed"; otherwise false.
+     */
+    public boolean isPaused() {
+        return this.status.equalsIgnoreCase("closed");
+    }
 }


### PR DESCRIPTION
[TDS_643](https://jira.fairwaytech.com/browse/TDS-643):  Added an `isPaused()` method to the `PauseSessionResponse` to make it easier to determine if a session has been paused (i.e. the session is in a "closed" status).  

**NOTE:** This PR provides support for the [TDS_Proctor pull request](https://github.com/SmarterApp/TDS_Proctor/pull/13) for `pauseSession` implementation.