### PR TITLE
Removing newStatus parameter from pauseSession

### DIFF
--- a/service/src/main/java/tds/session/repositories/SessionRepository.java
+++ b/service/src/main/java/tds/session/repositories/SessionRepository.java
@@ -27,7 +27,6 @@ public interface SessionRepository {
      * </p>
      *
      * @param sessionId The id of the {@link Session} to pause
-     * @param newStatus A description of why the {@link Session} is being paused
      */
-    void pause(final UUID sessionId, final String newStatus);
+    void pause(final UUID sessionId);
 }

--- a/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
+++ b/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
@@ -69,7 +69,7 @@ class SessionRepositoryImpl implements SessionRepository {
     }
 
     @Override
-    public void pause(final UUID sessionId, final String newStatus) {
+    public void pause(final UUID sessionId) {
         // Had to build the UTC Timestamp this way.  Using Timestamp utcTs = Timestamp.from(Instant.now()) would always
         // result in a Timestamp that reflected my local system clock settings.  Want to guarantee that dates/times are
         // always UTC, regardless of system clock.
@@ -77,7 +77,6 @@ class SessionRepositoryImpl implements SessionRepository {
 
         final SqlParameterSource parameters =
             new MapSqlParameterSource("id", UuidAdapter.getBytesFromUUID(sessionId))
-                .addValue("reason", newStatus)
                 .addValue("dateChanged", utcTs)
                 .addValue("dateEnd", utcTs);
 
@@ -87,7 +86,7 @@ class SessionRepositoryImpl implements SessionRepository {
             "UPDATE \n" +
                 "   session.session \n" +
                 "SET \n" +
-                "   status = :reason, \n" +
+                "   status = 'closed', \n" +
                 "   datechanged = :dateChanged, \n" +
                 "   dateend = :dateEnd \n" +
                 "WHERE \n" +

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -55,7 +55,7 @@ class SessionServiceImpl implements SessionService {
         }
 
         examService.pauseAllExamsInSession(sessionId);
-        sessionRepository.pause(sessionId, "closed");
+        sessionRepository.pause(sessionId);
 
         Session updatedSession = sessionRepository.findSessionById(sessionId)
             .orElseThrow(() -> new IllegalStateException(String.format("Could not find session that was just closed for session id %s", sessionId)));

--- a/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
@@ -151,14 +151,12 @@ public class SessionRepositoryImplIntegrationTests {
 
         insertSession(session);
 
-        final String status = "unit test";  // represents the status change sent in from the caller
-
-        sessionRepository.pause(sessionId, status);
+        sessionRepository.pause(sessionId);
 
         Optional<Session> result = sessionRepository.findSessionById(sessionId);
         assertThat(result).isPresent();
         assertThat(result.get().getId()).isEqualTo(sessionId);
-        assertThat(result.get().getStatus()).isEqualTo(status);
+        assertThat(result.get().getStatus()).isEqualTo("closed");
         assertThat(result.get().getDateChanged()).isNotNull();
         assertThat(result.get().getDateChanged()).isGreaterThan(result.get().getDateBegin());
         assertThat(result.get().getDateEnd()).isNotNull();

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -121,13 +121,13 @@ public class SessionServiceImplTest {
         when(mockSessionRepository.findSessionById(mockOpenSession.getId()))
             .thenReturn(Optional.of(mockOpenSession))
             .thenReturn(Optional.of(mockUpdatedSession));
-        doNothing().when(mockSessionRepository).pause(mockOpenSession.getId(), "closed");
+        doNothing().when(mockSessionRepository).pause(mockOpenSession.getId());
         doNothing().when(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
 
         Response<PauseSessionResponse> response = service.pause(mockOpenSession.getId(), request);
 
         verify(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
-        verify(mockSessionRepository).pause(mockOpenSession.getId(), "closed");
+        verify(mockSessionRepository).pause(mockOpenSession.getId());
         verify(mockSessionRepository, times(2)).findSessionById(mockOpenSession.getId());
 
         assertThat(response.getData()).isNotNull();
@@ -221,7 +221,7 @@ public class SessionServiceImplTest {
         Response<PauseSessionResponse> response = service.pause(sessionId, request);
 
         verify(mockExamService, times(0)).pauseAllExamsInSession(mockClosedSession.getId());
-        verify(mockSessionRepository, times(0)).pause(mockClosedSession.getId(), "closed");
+        verify(mockSessionRepository, times(0)).pause(mockClosedSession.getId());
         verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
 
         assertThat(response.getData().isPresent()).isFalse();


### PR DESCRIPTION
Removing the "status" argument since status will always be 'closed' when a session is paused.
https://jira.fairwaytech.com/browse/TDS-378