### PR TITLE
Feature/proctor ping

### DIFF
--- a/client/src/main/java/tds/session/Session.java
+++ b/client/src/main/java/tds/session/Session.java
@@ -95,6 +95,20 @@ public class Session {
             return this;
         }
 
+        public Builder fromSession(Session session) {
+            id = session.id;
+            sessionKey = session.sessionKey;
+            status = session.status;
+            dateBegin = session.dateBegin;
+            dateEnd = session.dateEnd;
+            dateChanged = session.dateChanged;
+            dateVisited = session.dateVisited;
+            clientName = session.clientName;
+            proctorId = session.proctorId;
+            browserKey = session.browserKey;
+            return this;
+        }
+
         public Session build() {
             return new Session(this);
         }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -136,7 +136,13 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
+        <!-- Random beans -->
+        <dependency>
+            <groupId>io.github.benas</groupId>
+            <artifactId>random-beans</artifactId>
+            <version>3.5.0</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>

--- a/service/src/main/java/tds/session/repositories/SessionRepository.java
+++ b/service/src/main/java/tds/session/repositories/SessionRepository.java
@@ -30,4 +30,12 @@ public interface SessionRepository {
      * @param newStatus A description of why the {@link Session} is being paused
      */
     void pause(final UUID sessionId, final String newStatus);
+
+    /**
+     * Updates the "datevisited" column of the session table to prevent the session from being closed from a timeout due
+     * to proctor inactivity.
+     *
+     * @param sessionId The id of the {@link tds.session.Session} to extend
+     */
+    void updateDateVisited(UUID sessionId);
 }

--- a/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
+++ b/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
@@ -24,6 +24,7 @@ import tds.common.data.mysql.UuidAdapter;
 import tds.session.Session;
 import tds.session.repositories.SessionRepository;
 
+import static tds.common.data.mapping.ResultSetMapperUtility.mapInstantToTimestamp;
 import static tds.common.data.mapping.ResultSetMapperUtility.mapTimestampToJodaInstant;
 
 @Repository
@@ -90,6 +91,30 @@ class SessionRepositoryImpl implements SessionRepository {
                 "   status = :reason, \n" +
                 "   datechanged = :dateChanged, \n" +
                 "   dateend = :dateEnd \n" +
+                "WHERE \n" +
+                "   _key = :id";
+
+        try {
+            jdbcTemplate.update(SQL, parameters);
+        } catch (DataAccessException e) {
+            log.error("{} UPDATE threw exception", SQL, e);
+            throw e;
+        }
+    }
+
+    @Override
+    public void updateDateVisited(final UUID sessionId) {
+        final SqlParameterSource parameters =
+            new MapSqlParameterSource("id", UuidAdapter.getBytesFromUUID(sessionId))
+                .addValue("dateVisited", mapInstantToTimestamp(Instant.now()));
+
+        // In order to preserve compatibility with the existing TDS system, this implementation executes an UPDATE
+        // against the existing record in the session.session table.
+        final String SQL =
+            "UPDATE \n" +
+                "   session.session \n" +
+                "SET \n" +
+                "   datevisited = :dateVisited \n" +
                 "WHERE \n" +
                 "   _key = :id";
 

--- a/service/src/main/java/tds/session/services/SessionService.java
+++ b/service/src/main/java/tds/session/services/SessionService.java
@@ -42,5 +42,12 @@ public interface SessionService {
      * @return {@link tds.session.SessionAssessment} if found otherwise empty
      */
     Optional<SessionAssessment> findSessionAssessment(final UUID sessionId, final String assessmentKey);
+
+    /**
+     * Updates the "date visited" of a {@link tds.session.Session} in order to maintain the session open.
+     *
+     * @param sessionId The id of the {@link tds.session.Session}
+     */
+    void updateDateVisited(UUID sessionId);
 }
 

--- a/service/src/main/java/tds/session/services/SessionService.java
+++ b/service/src/main/java/tds/session/services/SessionService.java
@@ -47,7 +47,9 @@ public interface SessionService {
      * Updates the "date visited" of a {@link tds.session.Session} in order to maintain the session open.
      *
      * @param sessionId The id of the {@link tds.session.Session}
+     *
+     * @return {@code true} if the session was successfully updated, {@code false} otherwise
      */
-    void updateDateVisited(UUID sessionId);
+    boolean updateDateVisited(UUID sessionId);
 }
 

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -69,6 +69,11 @@ class SessionServiceImpl implements SessionService {
         return sessionAssessmentQueryRepository.findSessionAssessment(sessionId, assessmentKey);
     }
 
+    @Override
+    public void updateDateVisited(final UUID sessionId) {
+        sessionRepository.updateDateVisited(sessionId);
+    }
+
     /**
      * Determine if the requested {@link tds.session.Session} can be paused.
      *

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -1,5 +1,7 @@
 package tds.session.services.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
@@ -24,6 +26,7 @@ import tds.session.services.SessionService;
 
 @Service
 class SessionServiceImpl implements SessionService {
+    private static final Logger log = LoggerFactory.getLogger(SessionServiceImpl.class);
     private final SessionRepository sessionRepository;
     private final SessionAssessmentQueryRepository sessionAssessmentQueryRepository;
     private final ExamService examService;
@@ -70,8 +73,17 @@ class SessionServiceImpl implements SessionService {
     }
 
     @Override
-    public void updateDateVisited(final UUID sessionId) {
+    public boolean updateDateVisited(final UUID sessionId) {
+        Optional<Session> maybeSession = sessionRepository.findSessionById(sessionId);
+
+        if (!maybeSession.isPresent()) {
+            log.error("No session for session id {} found. Unable to extend session.", sessionId);
+            return false;
+        }
+
         sessionRepository.updateDateVisited(sessionId);
+
+        return true;
     }
 
     /**

--- a/service/src/main/java/tds/session/web/endpoints/SessionController.java
+++ b/service/src/main/java/tds/session/web/endpoints/SessionController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
@@ -62,6 +63,12 @@ class SessionController {
         headers.setLocation(location);
 
         return new ResponseEntity<>(response, headers, HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "/{sessionId}/extend", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.OK)
+    void extendSession(@PathVariable final UUID sessionId) {
+        sessionService.updateDateVisited(sessionId);
     }
 
     @RequestMapping(value = "/{sessionId}/assessment/{assessmentKey}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/service/src/main/java/tds/session/web/endpoints/SessionController.java
+++ b/service/src/main/java/tds/session/web/endpoints/SessionController.java
@@ -36,7 +36,7 @@ class SessionController {
     private final SessionService sessionService;
 
     @Autowired
-    public SessionController(SessionService sessionService) {
+    public SessionController(final SessionService sessionService) {
         this.sessionService = sessionService;
     }
 
@@ -66,9 +66,14 @@ class SessionController {
     }
 
     @RequestMapping(value = "/{sessionId}/extend", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.OK)
-    void extendSession(@PathVariable final UUID sessionId) {
-        sessionService.updateDateVisited(sessionId);
+    ResponseEntity<Boolean> extendSession(@PathVariable final UUID sessionId) {
+        Boolean successful = sessionService.updateDateVisited(sessionId);
+
+        if (!successful) {
+            return new ResponseEntity<>(successful, HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+
+        return ResponseEntity.ok(successful);
     }
 
     @RequestMapping(value = "/{sessionId}/assessment/{assessmentKey}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import tds.session.Session;
 import tds.session.repositories.SessionRepository;
 
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tds.common.data.mapping.ResultSetMapperUtility.mapJodaInstantToTimestamp;
 import static tds.common.data.mysql.UuidAdapter.getBytesFromUUID;
@@ -163,6 +164,27 @@ public class SessionRepositoryImplIntegrationTests {
         assertThat(result.get().getDateChanged()).isGreaterThan(result.get().getDateBegin());
         assertThat(result.get().getDateEnd()).isNotNull();
         assertThat(result.get().getDateEnd()).isGreaterThan(result.get().getDateBegin());
+    }
+
+    @Test
+    public void shouldUpdateSessionDateVisited() {
+        Session session = new Session.Builder()
+            .fromSession(random(Session.class))
+            .withDateVisited(Instant.now().minus(99999))
+            .build();
+        insertSession(session);
+
+        assertThat(session.getDateVisited()).isNotNull();
+
+        Optional<Session> retSession = sessionRepository.findSessionById(session.getId());
+        assertThat(retSession).isPresent();
+
+        Instant priorDateVisited = retSession.get().getDateVisited();
+
+        sessionRepository.updateDateVisited(session.getId());
+        Optional<Session> updatedSession = sessionRepository.findSessionById(session.getId());
+        assertThat(updatedSession).isPresent();
+        assertThat(priorDateVisited.isBefore(updatedSession.get().getDateVisited())).isTrue();
     }
 
     private void insertSession(Session session) {

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -230,4 +230,11 @@ public class SessionServiceImplTest {
         assertThat(error.getCode()).isEqualTo(ValidationErrorCode.PAUSE_SESSION_ACCESS_VIOLATION);
         assertThat(error.getMessage()).isEqualTo("Unauthorized session access");
     }
+
+    @Test
+    public void shouldUpdateSessionService() {
+        final UUID sessionId = UUID.randomUUID();
+        service.updateDateVisited(sessionId);
+        verify(mockSessionRepository).updateDateVisited(sessionId);
+    }
 }

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -23,8 +23,10 @@ import tds.session.repositories.SessionRepository;
 import tds.session.services.ExamService;
 import tds.session.services.SessionService;
 
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -233,8 +235,24 @@ public class SessionServiceImplTest {
 
     @Test
     public void shouldUpdateSessionService() {
+        final Session session = random(Session.class);
+
+        when(mockSessionRepository.findSessionById(session.getId())).thenReturn(Optional.of(session));
+        boolean successful = service.updateDateVisited(session.getId());
+
+        assertThat(successful).isTrue();
+        verify(mockSessionRepository).findSessionById(session.getId());
+        verify(mockSessionRepository).updateDateVisited(session.getId());
+    }
+
+    @Test
+    public void shouldReturnFalseForNoSessionFound() {
         final UUID sessionId = UUID.randomUUID();
-        service.updateDateVisited(sessionId);
-        verify(mockSessionRepository).updateDateVisited(sessionId);
+
+        when(mockSessionRepository.findSessionById(sessionId)).thenReturn(Optional.empty());
+        assertThat(service.updateDateVisited(sessionId)).isFalse();
+
+        verify(mockSessionRepository).findSessionById(sessionId);
+        verify(mockSessionRepository, never()).updateDateVisited(sessionId);
     }
 }

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -181,9 +181,26 @@ public class SessionControllerIntegrationTests {
         final UriComponents components = UriComponentsBuilder
             .fromPath(String.format("/sessions/%s/extend", sessionId)).build();
 
+        when(mockSessionService.updateDateVisited(sessionId)).thenReturn(true);
+
         http.perform(put(components.toUri())
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk());
+
+        verify(mockSessionService).updateDateVisited(sessionId);
+    }
+
+    @Test
+    public void shouldReturnUnprocessableEntityForUnsuccessfulUpdate() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final UriComponents components = UriComponentsBuilder
+            .fromPath(String.format("/sessions/%s/extend", sessionId)).build();
+
+        when(mockSessionService.updateDateVisited(sessionId)).thenReturn(false);
+
+        http.perform(put(components.toUri())
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnprocessableEntity());
 
         verify(mockSessionService).updateDateVisited(sessionId);
     }

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -32,6 +32,7 @@ import tds.session.services.SessionService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -172,5 +173,18 @@ public class SessionControllerIntegrationTests {
         http.perform(get(components.toUri())
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void shouldUpdateDateVisitedForSession() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final UriComponents components = UriComponentsBuilder
+            .fromPath(String.format("/sessions/%s/extend", sessionId)).build();
+
+        http.perform(put(components.toUri())
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
+
+        verify(mockSessionService).updateDateVisited(sessionId);
     }
 }


### PR DESCRIPTION
/ProctorPing endpoint for update the "date visited" of a session - essentially this is done in order to extend the length of the session, and to prevent an inactivity timeout of a session.

This endpoint will be called by TDS_Proctor (periodically, every 2 minutes). That integration work will be part of a separate PR in TDS_Proctor.