### PR TITLE
Disable cloud bus for local development spring profile

### DIFF
--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -16,6 +16,7 @@ spring:
     throw-exception-if-no-handler-found: true
   resources:
     add-mappings: false
+  cloud.bus.enabled: false
 
 #Port defined in TDS_Build:docker-compose.yml
   rabbitmq:

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -16,7 +16,9 @@ spring:
     throw-exception-if-no-handler-found: true
   resources:
     add-mappings: false
-  cloud.bus.enabled: false
+  cloud:
+    bus:
+      enabled: false
 
 #Port defined in TDS_Build:docker-compose.yml
   rabbitmq:

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -9,7 +9,9 @@ spring:
     throw-exception-if-no-handler-found: true
   resources:
     add-mappings: false
-  cloud.bus.enabled: false
+  cloud:
+    bus:
+      enabled: false
 
 server:
   port: 8082

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -9,6 +9,7 @@ spring:
     throw-exception-if-no-handler-found: true
   resources:
     add-mappings: false
+  cloud.bus.enabled: false
 
 server:
   port: 8082


### PR DESCRIPTION
Spring cloud bus requires a running rabbitmq.
Prevents warning log messages when rabbitmq is not running.