### PR TITLE
Added endpoint for fetching multiple sessions at once

### DIFF
--- a/service/src/main/java/tds/session/repositories/SessionRepository.java
+++ b/service/src/main/java/tds/session/repositories/SessionRepository.java
@@ -11,14 +11,6 @@ import tds.session.Session;
  */
 public interface SessionRepository {
     /**
-     * Finds the Session by given id
-     *
-     * @param id session id
-     * @return optional containing {@link tds.session.Session Session} otherwise empty Optional
-     */
-    Optional<Session> findSessionById(final UUID id);
-
-    /**
      * Finds the list of {@link tds.session.Session}s for the specified session ids
      *
      * @param ids The ids of the {@link tds.session.Session}s to find

--- a/service/src/main/java/tds/session/repositories/SessionRepository.java
+++ b/service/src/main/java/tds/session/repositories/SessionRepository.java
@@ -1,5 +1,6 @@
 package tds.session.repositories;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,6 +17,14 @@ public interface SessionRepository {
      * @return optional containing {@link tds.session.Session Session} otherwise empty Optional
      */
     Optional<Session> findSessionById(final UUID id);
+
+    /**
+     * Finds the list of {@link tds.session.Session}s for the specified session ids
+     *
+     * @param ids The ids of the {@link tds.session.Session}s to find
+     * @return A list of sessions for the provided ids
+     */
+    List<Session> findSessionsByIds(final UUID... ids);
 
     /**
      * Pause an existing {@link Session}, updating the {@link Session}'s status to indicate it is no longer "open".

--- a/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
+++ b/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
@@ -42,17 +42,6 @@ class SessionRepositoryImpl implements SessionRepository {
     }
 
     @Override
-    public Optional<Session> findSessionById(final UUID id) {
-        List<Session> sessions = findSessionsByIds(id);
-
-        if (sessions.size() > 0) {
-            return Optional.of(sessions.get(0));
-        }
-
-        return Optional.empty();
-    }
-
-    @Override
     public List<Session> findSessionsByIds(final UUID... ids) {
         final SqlParameterSource parameters = new MapSqlParameterSource("ids",
             Arrays.asList(ids).stream()

--- a/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
+++ b/service/src/main/java/tds/session/repositories/impl/SessionRepositoryImpl.java
@@ -17,8 +17,11 @@ import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import tds.common.data.mysql.UuidAdapter;
 import tds.session.Session;
@@ -40,7 +43,22 @@ class SessionRepositoryImpl implements SessionRepository {
 
     @Override
     public Optional<Session> findSessionById(final UUID id) {
-        final SqlParameterSource parameters = new MapSqlParameterSource("id", UuidAdapter.getBytesFromUUID(id));
+        List<Session> sessions = findSessionsByIds(id);
+
+        if (sessions.size() > 0) {
+            return Optional.of(sessions.get(0));
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Session> findSessionsByIds(final UUID... ids) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("ids",
+            Arrays.asList(ids).stream()
+                .map(id -> UuidAdapter.getBytesFromUUID(id))
+                .collect(Collectors.toList())
+        );
 
         String query =
             "SELECT \n" +
@@ -62,16 +80,9 @@ class SessionRepositoryImpl implements SessionRepository {
                 "   session.tbluser u \n" +
                 "ON s._efk_proctor = u.userkey \n" +
                 "WHERE \n" +
-                "   s._key = :id";
+                "   s._key IN (:ids)";
 
-        Optional<Session> sessionOptional;
-        try {
-            sessionOptional = Optional.of(jdbcTemplate.queryForObject(query, parameters, sessionRowMapper));
-        } catch (EmptyResultDataAccessException e) {
-            sessionOptional = Optional.empty();
-        }
-
-        return sessionOptional;
+        return jdbcTemplate.query(query, parameters, sessionRowMapper);
     }
 
     @Override

--- a/service/src/main/java/tds/session/services/SessionService.java
+++ b/service/src/main/java/tds/session/services/SessionService.java
@@ -59,5 +59,13 @@ public interface SessionService {
      * @return the list of all {@link tds.session.SessionAssessment}s for this session
      */
     List<SessionAssessment> findSessionAssessments(final UUID sessionId);
+
+    /**
+     * Finds the list of {@link tds.session.Session}s for the specified session ids
+     *
+     * @param sessionIds The ids of the {@link tds.session.Session}s to find
+     * @return A list of sessions for the provided ids
+     */
+    List<Session> findSessionsByIds(final UUID... sessionIds);
 }
 

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -92,6 +92,11 @@ class SessionServiceImpl implements SessionService {
         return sessionAssessmentQueryRepository.findSessionAssessments(sessionId);
     }
 
+    @Override
+    public List<Session> findSessionsByIds(final UUID... sessionIds) {
+        return sessionRepository.findSessionsByIds(sessionIds);
+    }
+
     /**
      * Determine if the requested {@link tds.session.Session} can be paused.
      *

--- a/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/session/services/impl/SessionServiceImpl.java
@@ -44,13 +44,13 @@ class SessionServiceImpl implements SessionService {
     @Override
     @Cacheable(CacheType.SHORT_TERM)
     public Optional<Session> findSessionById(final UUID id) {
-        return sessionRepository.findSessionById(id);
+        return sessionRepository.findSessionsByIds(id).stream().findFirst();
     }
 
     @Transactional
     @Override
     public Response<PauseSessionResponse> pause(final UUID sessionId, final PauseSessionRequest request) {
-        final Session session = sessionRepository.findSessionById(sessionId)
+        final Session session = findSessionById(sessionId)
             .orElseThrow(() -> new NotFoundException(String.format("Could not find session for session id %s", sessionId)));
 
         Optional<ValidationError> maybeValidationError = verifySessionCanBePaused(session, request);
@@ -61,7 +61,7 @@ class SessionServiceImpl implements SessionService {
         examService.pauseAllExamsInSession(sessionId);
         sessionRepository.pause(sessionId);
 
-        Session updatedSession = sessionRepository.findSessionById(sessionId)
+        Session updatedSession = findSessionById(sessionId)
             .orElseThrow(() -> new IllegalStateException(String.format("Could not find session that was just closed for session id %s", sessionId)));
 
         return new Response<>(new PauseSessionResponse(updatedSession));
@@ -75,7 +75,7 @@ class SessionServiceImpl implements SessionService {
 
     @Override
     public boolean updateDateVisited(final UUID sessionId) {
-        Optional<Session> maybeSession = sessionRepository.findSessionById(sessionId);
+        Optional<Session> maybeSession = findSessionById(sessionId);
 
         if (!maybeSession.isPresent()) {
             log.error("No session for session id {} found. Unable to extend session.", sessionId);

--- a/service/src/main/java/tds/session/web/endpoints/SessionController.java
+++ b/service/src/main/java/tds/session/web/endpoints/SessionController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,6 +49,12 @@ class SessionController {
             .orElseThrow(() -> new NotFoundException("Could not find session for %s", sessionId));
 
         return ResponseEntity.ok(session);
+    }
+
+    @RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    ResponseEntity<List<Session>> findSessionsByIds(@RequestParam("sessionId") final UUID... sessionIds) {
+        return ResponseEntity.ok(sessionService.findSessionsByIds(sessionIds));
     }
 
     @RequestMapping(value = "/{sessionId}/pause", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/service/src/main/java/tds/session/web/endpoints/SessionController.java
+++ b/service/src/main/java/tds/session/web/endpoints/SessionController.java
@@ -51,7 +51,7 @@ class SessionController {
         return ResponseEntity.ok(session);
     }
 
-    @RequestMapping(value = "/", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     ResponseEntity<List<Session>> findSessionsByIds(@RequestParam("sessionId") final UUID... sessionIds) {
         return ResponseEntity.ok(sessionService.findSessionsByIds(sessionIds));

--- a/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
@@ -112,7 +112,7 @@ public class SessionRepositoryImplIntegrationTests {
         assertThat(retSession1.getProctorName()).isEqualTo(session1.getProctorName());
         assertThat(retSession1.getProctorEmail()).isEqualTo(session1.getProctorEmail());
 
-        assertThat(retSession2.getId()).isEqualTo(session2.getId());
+        assertThat(retSession2).isNotNull();
     }
 
     @Test
@@ -143,19 +143,19 @@ public class SessionRepositoryImplIntegrationTests {
 
         insertSession(session, true);
 
-        Optional<Session> sessionOptional = sessionRepository.findSessionById(sessionId);
-        assertThat(sessionOptional).isPresent();
-        assertThat(sessionOptional.get().getId()).isEqualTo(sessionId);
-        assertThat(sessionOptional.get().getStatus()).isEqualTo("closed");
-        assertThat(sessionOptional.get().getDateBegin()).isEqualByComparingTo(dateBegin);
-        assertThat(sessionOptional.get().getDateChanged()).isEqualTo(dateChanged);
-        assertThat(sessionOptional.get().getDateEnd()).isEqualTo(dateEnded);
-        assertThat(sessionOptional.get().getDateVisited()).isEqualTo(dateVisited);
-        assertThat(sessionOptional.get().getClientName()).isEqualTo("SBAC_PT");
-        assertThat(sessionOptional.get().getProctorId()).isEqualTo(23);
-        assertThat(sessionOptional.get().getBrowserKey()).isEqualTo(browserKey);
-        assertThat(sessionOptional.get().getProctorName()).isEqualTo(proctorName);
-        assertThat(sessionOptional.get().getProctorEmail()).isEqualTo(proctorEmail);
+        List<Session> retSessions = sessionRepository.findSessionsByIds(sessionId);
+        Session retSession = retSessions.get(0);
+        assertThat(retSession.getId()).isEqualTo(sessionId);
+        assertThat(retSession.getStatus()).isEqualTo("closed");
+        assertThat(retSession.getDateBegin()).isEqualByComparingTo(dateBegin);
+        assertThat(retSession.getDateChanged()).isEqualTo(dateChanged);
+        assertThat(retSession.getDateEnd()).isEqualTo(dateEnded);
+        assertThat(retSession.getDateVisited()).isEqualTo(dateVisited);
+        assertThat(retSession.getClientName()).isEqualTo("SBAC_PT");
+        assertThat(retSession.getProctorId()).isEqualTo(23);
+        assertThat(retSession.getBrowserKey()).isEqualTo(browserKey);
+        assertThat(retSession.getProctorName()).isEqualTo(proctorName);
+        assertThat(retSession.getProctorEmail()).isEqualTo(proctorEmail);
     }
 
     @Test
@@ -173,22 +173,22 @@ public class SessionRepositoryImplIntegrationTests {
 
         insertSession(session, true);
 
-        Optional<Session> sessionOptional = sessionRepository.findSessionById(sessionId);
-        assertThat(sessionOptional).isPresent();
-        assertThat(sessionOptional.get().getId()).isEqualTo(sessionId);
-        assertThat(sessionOptional.get().getStatus()).isEqualTo("open");
-        assertThat(sessionOptional.get().getDateBegin()).isNull();
-        assertThat(sessionOptional.get().getDateEnd()).isNull();
-        assertThat(sessionOptional.get().getDateChanged()).isNull();
-        assertThat(sessionOptional.get().getDateVisited()).isNull();
-        assertThat(sessionOptional.get().getProctorId()).isEqualTo(99L);
-        assertThat(sessionOptional.get().getBrowserKey()).isEqualTo(browserKey);
+        List<Session> retSessions = sessionRepository.findSessionsByIds(sessionId);
+        Session retSession = retSessions.get(0);
+        assertThat(retSession.getId()).isEqualTo(sessionId);
+        assertThat(retSession.getStatus()).isEqualTo("open");
+        assertThat(retSession.getDateBegin()).isNull();
+        assertThat(retSession.getDateEnd()).isNull();
+        assertThat(retSession.getDateChanged()).isNull();
+        assertThat(retSession.getDateVisited()).isNull();
+        assertThat(retSession.getProctorId()).isEqualTo(99L);
+        assertThat(retSession.getBrowserKey()).isEqualTo(browserKey);
     }
 
     @Test
     public void shouldHandleWhenSessionCannotBeFoundById() {
-        Optional<Session> sessionOptional = sessionRepository.findSessionById(UUID.randomUUID());
-        assertThat(sessionOptional).isNotPresent();
+        List<Session> retSessions = sessionRepository.findSessionsByIds(UUID.randomUUID());
+        assertThat(retSessions).isEmpty();
     }
 
     @Test
@@ -208,10 +208,10 @@ public class SessionRepositoryImplIntegrationTests {
 
         insertSession(session, false);
 
-        Optional<Session> sessionOptional = sessionRepository.findSessionById(sessionId);
-        assertThat(sessionOptional).isPresent();
-        assertThat(sessionOptional.get().getProctorId()).isNull();
-        assertThat(sessionOptional.get().getProctorEmail()).isNull();
+        List<Session> retSessions = sessionRepository.findSessionsByIds(sessionId);
+        Session retSession = retSessions.get(0);
+        assertThat(retSession.getProctorId()).isNull();
+        assertThat(retSession.getProctorEmail()).isNull();
     }
 
     @Test
@@ -234,14 +234,14 @@ public class SessionRepositoryImplIntegrationTests {
 
         sessionRepository.pause(sessionId);
 
-        Optional<Session> result = sessionRepository.findSessionById(sessionId);
-        assertThat(result).isPresent();
-        assertThat(result.get().getId()).isEqualTo(sessionId);
-        assertThat(result.get().getStatus()).isEqualTo("closed");
-        assertThat(result.get().getDateChanged()).isNotNull();
-        assertThat(result.get().getDateChanged()).isGreaterThan(result.get().getDateBegin());
-        assertThat(result.get().getDateEnd()).isNotNull();
-        assertThat(result.get().getDateEnd()).isGreaterThan(result.get().getDateBegin());
+        List<Session> results = sessionRepository.findSessionsByIds(sessionId);
+        Session retSession = results.get(0);
+        assertThat(retSession.getId()).isEqualTo(sessionId);
+        assertThat(retSession.getStatus()).isEqualTo("closed");
+        assertThat(retSession.getDateChanged()).isNotNull();
+        assertThat(retSession.getDateChanged()).isGreaterThan(retSession.getDateBegin());
+        assertThat(retSession.getDateEnd()).isNotNull();
+        assertThat(retSession.getDateEnd()).isGreaterThan(retSession.getDateBegin());
     }
 
     @Test
@@ -254,15 +254,16 @@ public class SessionRepositoryImplIntegrationTests {
 
         assertThat(session.getDateVisited()).isNotNull();
 
-        Optional<Session> retSession = sessionRepository.findSessionById(session.getId());
-        assertThat(retSession).isPresent();
+        List<Session> retSessions = sessionRepository.findSessionsByIds(session.getId());
+        Session retSession = retSessions.get(0);
+        assertThat(retSessions).hasSize(1);
 
-        Instant priorDateVisited = retSession.get().getDateVisited();
+        Instant priorDateVisited = retSession.getDateVisited();
 
         sessionRepository.updateDateVisited(session.getId());
-        Optional<Session> updatedSession = sessionRepository.findSessionById(session.getId());
-        assertThat(updatedSession).isPresent();
-        assertThat(priorDateVisited.isBefore(updatedSession.get().getDateVisited())).isTrue();
+        List<Session> updateSessions = sessionRepository.findSessionsByIds(session.getId());
+        Session updateSession = updateSessions.get(0);
+        assertThat(priorDateVisited.isBefore(updateSession.getDateVisited())).isTrue();
     }
 
     private void insertSession(Session session, boolean insertProctorData) {

--- a/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/session/repositories/impl/SessionRepositoryImplIntegrationTests.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.text.ParseException;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -76,6 +77,42 @@ public class SessionRepositoryImplIntegrationTests {
 
     @After
     public void tearDown() {
+    }
+
+    @Test
+    public void shouldRetrieveSessionsForIds() throws ParseException {
+        Session session1 = random(Session.class);
+        Session session2 = random(Session.class);
+
+        insertSession(session1, true);
+        insertSession(session2, true);
+
+        List<Session> retSessions = sessionRepository.findSessionsByIds(session1.getId(), session2.getId());
+
+        Session retSession1 = null;
+        Session retSession2 = null;
+
+        for (Session s : retSessions) {
+            if (s.getId().equals(session1.getId())) {
+                retSession1 = s;
+            } else if (s.getId().equals(session2.getId())) {
+                retSession2 = s;
+            }
+        }
+
+        assertThat(retSession1.getId()).isEqualTo(session1.getId());
+        assertThat(retSession1.getStatus()).isEqualTo(session1.getStatus());
+        assertThat(retSession1.getDateBegin()).isEqualByComparingTo(session1.getDateBegin());
+        assertThat(retSession1.getDateChanged()).isEqualTo(session1.getDateChanged());
+        assertThat(retSession1.getDateEnd()).isEqualTo(session1.getDateEnd());
+        assertThat(retSession1.getDateVisited()).isEqualTo(session1.getDateVisited());
+        assertThat(retSession1.getClientName()).isEqualTo(session1.getClientName());
+        assertThat(retSession1.getProctorId()).isEqualTo(session1.getProctorId());
+        assertThat(retSession1.getBrowserKey()).isEqualTo(session1.getBrowserKey());
+        assertThat(retSession1.getProctorName()).isEqualTo(session1.getProctorName());
+        assertThat(retSession1.getProctorEmail()).isEqualTo(session1.getProctorEmail());
+
+        assertThat(retSession2.getId()).isEqualTo(session2.getId());
     }
 
     @Test

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplIntegrationTests.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplIntegrationTests.java
@@ -9,6 +9,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
+import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -37,7 +38,7 @@ public class SessionServiceImplIntegrationTests {
         Session session = new Session.Builder()
             .withId(id)
             .build();
-        when(mockSessionRepository.findSessionById(id)).thenReturn(Optional.of(session));
+        when(mockSessionRepository.findSessionsByIds(id)).thenReturn(Collections.singletonList(session));
 
         Optional<Session> sessionOptional1 = sessionService.findSessionById(id);
         Optional<Session> sessionOptional2 = sessionService.findSessionById(id);
@@ -45,6 +46,6 @@ public class SessionServiceImplIntegrationTests {
         assertThat(sessionOptional1).isPresent();
         assertThat(sessionOptional1).isEqualTo(sessionOptional2);
 
-        verify(mockSessionRepository, times(1)).findSessionById(id);
+        verify(mockSessionRepository, times(1)).findSessionsByIds(id);
     }
 }

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -8,7 +8,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -63,20 +65,20 @@ public class SessionServiceImplTest {
         Session session = new Session.Builder()
             .withId(id)
             .build();
-        when(mockSessionRepository.findSessionById(id)).thenReturn(Optional.of(session));
+        when(mockSessionRepository.findSessionsByIds(id)).thenReturn(Collections.singletonList(session));
 
         Optional<Session> sessionOptional = service.findSessionById(id);
 
         assertThat(sessionOptional).isPresent();
         assertThat(sessionOptional.get().getId()).isEqualTo(id);
 
-        verify(mockSessionRepository).findSessionById(id);
+        verify(mockSessionRepository).findSessionsByIds(id);
     }
 
     @Test
     public void shouldReturnOptionalEmptyForInvalidSessionId() {
         UUID id = UUID.randomUUID();
-        when(mockSessionRepository.findSessionById(id)).thenReturn(Optional.empty());
+        when(mockSessionRepository.findSessionsByIds(id)).thenReturn(new ArrayList<>());
 
         Optional<Session> result = service.findSessionById(id);
 
@@ -171,9 +173,9 @@ public class SessionServiceImplTest {
 
         PauseSessionRequest request = new PauseSessionRequest(proctorId, browserKey);
 
-        when(mockSessionRepository.findSessionById(mockOpenSession.getId()))
-            .thenReturn(Optional.of(mockOpenSession))
-            .thenReturn(Optional.of(mockUpdatedSession));
+        when(mockSessionRepository.findSessionsByIds(mockOpenSession.getId()))
+            .thenReturn(Collections.singletonList(mockOpenSession))
+            .thenReturn(Collections.singletonList(mockUpdatedSession));
         doNothing().when(mockSessionRepository).pause(mockOpenSession.getId());
         doNothing().when(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
 
@@ -181,7 +183,7 @@ public class SessionServiceImplTest {
 
         verify(mockExamService).pauseAllExamsInSession(mockOpenSession.getId());
         verify(mockSessionRepository).pause(mockOpenSession.getId());
-        verify(mockSessionRepository, times(2)).findSessionById(mockOpenSession.getId());
+        verify(mockSessionRepository, times(2)).findSessionsByIds(mockOpenSession.getId());
 
         assertThat(response.getData()).isNotNull();
         assertThat(response.hasError()).isFalse();
@@ -207,12 +209,12 @@ public class SessionServiceImplTest {
 
         PauseSessionRequest request = new PauseSessionRequest(proctorId, browserKey);
 
-        when(mockSessionRepository.findSessionById(mockClosedSession.getId())).thenReturn(Optional.of(mockClosedSession));
+        when(mockSessionRepository.findSessionsByIds(mockClosedSession.getId())).thenReturn(Collections.singletonList(mockClosedSession));
 
         Response<PauseSessionResponse> response = service.pause(sessionId, request);
 
         verifyZeroInteractions(mockExamService);
-        verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
+        verify(mockSessionRepository, times(1)).findSessionsByIds(mockClosedSession.getId());
         verifyNoMoreInteractions(mockSessionRepository);
 
         assertThat(response.getData().isPresent()).isFalse();
@@ -237,12 +239,12 @@ public class SessionServiceImplTest {
 
         PauseSessionRequest request = new PauseSessionRequest(proctorId, browserKey);
 
-        when(mockSessionRepository.findSessionById(mockClosedSession.getId())).thenReturn(Optional.of(mockClosedSession));
+        when(mockSessionRepository.findSessionsByIds(mockClosedSession.getId())).thenReturn(Collections.singletonList(mockClosedSession));
 
         Response<PauseSessionResponse> response = service.pause(sessionId, request);
 
         verifyZeroInteractions(mockExamService);
-        verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
+        verify(mockSessionRepository, times(1)).findSessionsByIds(mockClosedSession.getId());
         verifyNoMoreInteractions(mockSessionRepository);
 
         assertThat(response.getData().isPresent()).isFalse();
@@ -268,14 +270,14 @@ public class SessionServiceImplTest {
 
         PauseSessionRequest request = new PauseSessionRequest(proctorId, browserKey);
 
-        when(mockSessionRepository.findSessionById(mockClosedSession.getId())).thenReturn(Optional.of(mockClosedSession));
+        when(mockSessionRepository.findSessionsByIds(mockClosedSession.getId())).thenReturn(Collections.singletonList(mockClosedSession));
         doNothing().when(mockExamService).pauseAllExamsInSession(mockClosedSession.getId());
 
         Response<PauseSessionResponse> response = service.pause(sessionId, request);
 
         verify(mockExamService, times(0)).pauseAllExamsInSession(mockClosedSession.getId());
         verify(mockSessionRepository, times(0)).pause(mockClosedSession.getId());
-        verify(mockSessionRepository, times(1)).findSessionById(mockClosedSession.getId());
+        verify(mockSessionRepository, times(1)).findSessionsByIds(mockClosedSession.getId());
 
         assertThat(response.getData().isPresent()).isFalse();
         assertThat(response.hasError()).isTrue();
@@ -288,11 +290,11 @@ public class SessionServiceImplTest {
     public void shouldUpdateSessionService() {
         final Session session = random(Session.class);
 
-        when(mockSessionRepository.findSessionById(session.getId())).thenReturn(Optional.of(session));
+        when(mockSessionRepository.findSessionsByIds(session.getId())).thenReturn(Collections.singletonList(session));
         boolean successful = service.updateDateVisited(session.getId());
 
         assertThat(successful).isTrue();
-        verify(mockSessionRepository).findSessionById(session.getId());
+        verify(mockSessionRepository).findSessionsByIds(session.getId());
         verify(mockSessionRepository).updateDateVisited(session.getId());
     }
 
@@ -300,10 +302,10 @@ public class SessionServiceImplTest {
     public void shouldReturnFalseForNoSessionFound() {
         final UUID sessionId = UUID.randomUUID();
 
-        when(mockSessionRepository.findSessionById(sessionId)).thenReturn(Optional.empty());
+        when(mockSessionRepository.findSessionsByIds(sessionId)).thenReturn(new ArrayList<>());
         assertThat(service.updateDateVisited(sessionId)).isFalse();
 
-        verify(mockSessionRepository).findSessionById(sessionId);
+        verify(mockSessionRepository).findSessionsByIds(sessionId);
         verify(mockSessionRepository, never()).updateDateVisited(sessionId);
     }
 }

--- a/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/session/services/impl/SessionServiceImplTest.java
@@ -111,6 +111,41 @@ public class SessionServiceImplTest {
     }
 
     @Test
+    public void shouldFindAllSessionsForSessionId() {
+        Session session1 = random(Session.class);
+        Session session2 = random(Session.class);
+
+        when(mockSessionRepository.findSessionsByIds(session1.getId(), session2.getId()))
+            .thenReturn(Arrays.asList(session1, session2));
+        List<Session> retSessions = service.findSessionsByIds(session1.getId(), session2.getId());
+
+        Session retSession1 = null;
+        Session retSession2 = null;
+
+        for (Session s : retSessions) {
+            if (s.getId().equals(session1.getId())) {
+                retSession1 = s;
+            } else if (s.getId().equals(session2.getId())) {
+                retSession2 = s;
+            }
+        }
+
+        assertThat(retSession1.getId()).isEqualTo(session1.getId());
+        assertThat(retSession1.getStatus()).isEqualTo(session1.getStatus());
+        assertThat(retSession1.getDateBegin()).isEqualByComparingTo(session1.getDateBegin());
+        assertThat(retSession1.getDateChanged()).isEqualTo(session1.getDateChanged());
+        assertThat(retSession1.getDateEnd()).isEqualTo(session1.getDateEnd());
+        assertThat(retSession1.getDateVisited()).isEqualTo(session1.getDateVisited());
+        assertThat(retSession1.getClientName()).isEqualTo(session1.getClientName());
+        assertThat(retSession1.getProctorId()).isEqualTo(session1.getProctorId());
+        assertThat(retSession1.getBrowserKey()).isEqualTo(session1.getBrowserKey());
+        assertThat(retSession1.getProctorName()).isEqualTo(session1.getProctorName());
+        assertThat(retSession1.getProctorEmail()).isEqualTo(session1.getProctorEmail());
+
+        assertThat(retSession2.getId()).isEqualTo(session2.getId());
+    }
+
+    @Test
     public void shouldPauseAllExamsInSession() {
         long proctorId = 1L;
         UUID sessionId = UUID.randomUUID();

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -3,7 +3,6 @@ package tds.session.web.endpoints;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.joda.time.Instant;
-import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -82,7 +81,7 @@ public class SessionControllerIntegrationTests {
 
         when(mockSessionService.findSessionsByIds(session1.getId(), session2.getId())).thenReturn(Arrays.asList(session1, session2));
 
-        http.perform(get(new URI("/sessions/"))
+        MvcResult result = http.perform(get(new URI("/sessions/"))
             .contentType(MediaType.APPLICATION_JSON)
             .param("sessionId", session1.getId().toString())
             .param("sessionId", session2.getId().toString()))
@@ -98,8 +97,17 @@ public class SessionControllerIntegrationTests {
             .andExpect(jsonPath("[1].proctorName", is(session2.getProctorName())))
             .andExpect(jsonPath("[1].sessionKey", is(session2.getSessionKey())))
             .andExpect(jsonPath("[1].proctorId", is(session2.getProctorId())))
-            .andExpect(jsonPath("[1].browserKey", is(session2.getBrowserKey().toString())));
+            .andExpect(jsonPath("[1].browserKey", is(session2.getBrowserKey().toString())))
+            .andReturn();
 
+
+        List<Session> parsedSessions = objectMapper.readValue(result.getResponse().getContentAsByteArray(), new TypeReference<List<Session>>() {});
+        assertThat(parsedSessions).hasSize(2);
+        Session retSession1 = parsedSessions.get(0);
+        Session retSession2 = parsedSessions.get(1);
+
+        assertThat(retSession1.getId()).isEqualTo(session1.getId());
+        assertThat(retSession2.getId()).isEqualTo(session2.getId());
     }
 
     @Test

--- a/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
+++ b/service/src/test/java/tds/session/web/endpoints/SessionControllerIntegrationTests.java
@@ -76,6 +76,33 @@ public class SessionControllerIntegrationTests {
     }
 
     @Test
+    public void shouldReturnSessionsByIds() throws Exception {
+        final Session session1 = random(Session.class);
+        final Session session2 = random(Session.class);
+
+        when(mockSessionService.findSessionsByIds(session1.getId(), session2.getId())).thenReturn(Arrays.asList(session1, session2));
+
+        http.perform(get(new URI("/sessions/"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("sessionId", session1.getId().toString())
+            .param("sessionId", session2.getId().toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("[0].id", is(session1.getId().toString())))
+            .andExpect(jsonPath("[0].status", is(session1.getStatus())))
+            .andExpect(jsonPath("[0].proctorName", is(session1.getProctorName())))
+            .andExpect(jsonPath("[0].sessionKey", is(session1.getSessionKey())))
+            .andExpect(jsonPath("[0].proctorId", is(session1.getProctorId())))
+            .andExpect(jsonPath("[0].browserKey", is(session1.getBrowserKey().toString())))
+            .andExpect(jsonPath("[1].id", is(session2.getId().toString())))
+            .andExpect(jsonPath("[1].status", is(session2.getStatus())))
+            .andExpect(jsonPath("[1].proctorName", is(session2.getProctorName())))
+            .andExpect(jsonPath("[1].sessionKey", is(session2.getSessionKey())))
+            .andExpect(jsonPath("[1].proctorId", is(session2.getProctorId())))
+            .andExpect(jsonPath("[1].browserKey", is(session2.getBrowserKey().toString())));
+
+    }
+
+    @Test
     public void shouldReturnNotFoundWhenSessionCannotBeFoundById() throws Exception {
         UUID id = UUID.randomUUID();
         when(mockSessionService.findSessionById(id)).thenReturn(Optional.empty());


### PR DESCRIPTION
Used by exam "get eligible exam" logic - we need to fetch the session object corresponding to each exam for  validation purposes (specifically, to determine whether or not an exam is resumable).